### PR TITLE
[이지표] setp-3 DB에 저장하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+### Config file ###
+config.properties

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,16 @@
 FROM tomcat:10-jdk17
 
-# Install Maven
 RUN apt-get update && \
     apt-get install -y maven
 
-# Copy your project files
 COPY . /usr/local/tomcat/webapps/myapp
 
-# Set working directory
 WORKDIR /usr/local/tomcat/webapps/myapp
 
-# Build the project
 RUN mvn clean package
 
-# Move the WAR file to Tomcat webapps directory
 RUN mv target/*.war /usr/local/tomcat/webapps/ROOT.war
 
-# Remove source files and Maven local repository to reduce image size
 RUN rm -rf /usr/local/tomcat/webapps/myapp /root/.m2
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM tomcat:10-jdk17
+
+# Install Maven
+RUN apt-get update && \
+    apt-get install -y maven
+
+# Copy your project files
+COPY . /usr/local/tomcat/webapps/myapp
+
+# Set working directory
+WORKDIR /usr/local/tomcat/webapps/myapp
+
+# Build the project
+RUN mvn clean package
+
+# Move the WAR file to Tomcat webapps directory
+RUN mv target/*.war /usr/local/tomcat/webapps/ROOT.war
+
+# Remove source files and Maven local repository to reduce image size
+RUN rm -rf /usr/local/tomcat/webapps/myapp /root/.m2
+
+EXPOSE 8080
+
+CMD ["catalina.sh", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,3 @@ RUN mv target/*.war /usr/local/tomcat/webapps/ROOT.war
 RUN rm -rf /usr/local/tomcat/webapps/myapp /root/.m2
 
 EXPOSE 8080
-
-CMD ["catalina.sh", "run"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3'
+
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: jspcafe
+      MYSQL_DATABASE: jspcafe
+      MYSQL_USER: jspcafe
+      MYSQL_PASSWORD: jspcafe
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+      - ./src/main/resources/init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  tomcat:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mysql
+
+volumes:
+  mysql-data:

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
             <version>2.17.2</version>
         </dependency>
         <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.4.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>${junit.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/jspcafe/board/controller/ArticleController.java
+++ b/src/main/java/com/jspcafe/board/controller/ArticleController.java
@@ -28,6 +28,7 @@ public class ArticleController extends HttpServlet {
         String path = req.getPathInfo();
         if (path == null || path.isEmpty() || path.isBlank()) {
             articleList(req, resp);
+            return;
         }
         switch (path) {
             case "/form" -> forward("article_form", req, resp);

--- a/src/main/java/com/jspcafe/board/controller/ArticleController.java
+++ b/src/main/java/com/jspcafe/board/controller/ArticleController.java
@@ -18,8 +18,8 @@ public class ArticleController extends HttpServlet {
     private ArticleService articleService;
 
     @Override
-    public void init() throws ServletException {
-        ServletContext ctx = getServletContext();
+    public void init(ServletConfig config) {
+        ServletContext ctx = config.getServletContext();
         articleService = (ArticleService) ctx.getAttribute("articleService");
     }
 

--- a/src/main/java/com/jspcafe/board/model/ArticleDao.java
+++ b/src/main/java/com/jspcafe/board/model/ArticleDao.java
@@ -3,7 +3,9 @@ package com.jspcafe.board.model;
 import com.jspcafe.util.DatabaseConnector;
 
 import java.sql.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 public class ArticleDao {
     private final DatabaseConnector databaseConnector;

--- a/src/main/java/com/jspcafe/board/model/ArticleDao.java
+++ b/src/main/java/com/jspcafe/board/model/ArticleDao.java
@@ -1,20 +1,67 @@
 package com.jspcafe.board.model;
 
+import com.jspcafe.util.DBManager;
+
+import java.sql.*;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class ArticleDao {
-    private final Map<String, Article> articles = new ConcurrentHashMap<>();
 
     public void save(final Article article) {
-        articles.put(article.id(), article);
+        String sql = "INSERT INTO articles (id, title, nickname, content, create_at) VALUES (?, ?, ?, ?, ?)";
+        try (Connection conn = DBManager.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setString(1, article.id());
+            pstmt.setString(2, article.title());
+            pstmt.setString(3, article.nickname());
+            pstmt.setString(4, article.content());
+            pstmt.setTimestamp(5, Timestamp.valueOf(article.createAt()));
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Error saving article", e);
+        }
     }
 
     public Optional<Article> findById(final String id) {
-        return Optional.ofNullable(articles.get(id));
+        String sql = "SELECT * FROM articles WHERE id = ?";
+        try (Connection conn = DBManager.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setString(1, id);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(new Article(
+                            rs.getString("id"),
+                            rs.getString("title"),
+                            rs.getString("nickname"),
+                            rs.getString("content"),
+                            rs.getTimestamp("create_at").toLocalDateTime()
+                    ));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Error finding article by id", e);
+        }
+        return Optional.empty();
     }
 
     public List<Article> findAll() {
-        return new ArrayList<>(articles.values());
+        String sql = "SELECT * FROM articles ORDER BY create_at DESC";
+        List<Article> articles = new ArrayList<>();
+        try (Connection conn = DBManager.getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery(sql)) {
+            while (rs.next()) {
+                articles.add(new Article(
+                        rs.getString("id"),
+                        rs.getString("title"),
+                        rs.getString("nickname"),
+                        rs.getString("content"),
+                        rs.getTimestamp("create_at").toLocalDateTime()
+                ));
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Error finding all articles", e);
+        }
+        return articles;
     }
 }

--- a/src/main/java/com/jspcafe/board/model/ArticleDao.java
+++ b/src/main/java/com/jspcafe/board/model/ArticleDao.java
@@ -1,15 +1,20 @@
 package com.jspcafe.board.model;
 
-import com.jspcafe.util.DBManager;
+import com.jspcafe.util.DatabaseConnector;
 
 import java.sql.*;
 import java.util.*;
 
 public class ArticleDao {
+    private final DatabaseConnector databaseConnector;
+
+    public ArticleDao(final DatabaseConnector databaseConnector) {
+        this.databaseConnector = databaseConnector;
+    }
 
     public void save(final Article article) {
         String sql = "INSERT INTO articles (id, title, nickname, content, create_at) VALUES (?, ?, ?, ?, ?)";
-        try (Connection conn = DBManager.getConnection();
+        try (Connection conn = databaseConnector.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
             pstmt.setString(1, article.id());
             pstmt.setString(2, article.title());
@@ -24,7 +29,7 @@ public class ArticleDao {
 
     public Optional<Article> findById(final String id) {
         String sql = "SELECT * FROM articles WHERE id = ?";
-        try (Connection conn = DBManager.getConnection();
+        try (Connection conn = databaseConnector.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
             pstmt.setString(1, id);
             try (ResultSet rs = pstmt.executeQuery()) {
@@ -47,7 +52,7 @@ public class ArticleDao {
     public List<Article> findAll() {
         String sql = "SELECT * FROM articles ORDER BY create_at DESC";
         List<Article> articles = new ArrayList<>();
-        try (Connection conn = DBManager.getConnection();
+        try (Connection conn = databaseConnector.getConnection();
              Statement stmt = conn.createStatement();
              ResultSet rs = stmt.executeQuery(sql)) {
             while (rs.next()) {

--- a/src/main/java/com/jspcafe/container/AppContextListener.java
+++ b/src/main/java/com/jspcafe/container/AppContextListener.java
@@ -4,6 +4,8 @@ import com.jspcafe.board.model.ArticleDao;
 import com.jspcafe.board.service.ArticleService;
 import com.jspcafe.user.model.UserDao;
 import com.jspcafe.user.service.UserService;
+import com.jspcafe.util.DatabaseConnector;
+import com.jspcafe.util.MysqlConnector;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
@@ -14,14 +16,19 @@ public class AppContextListener implements ServletContextListener {
     @Override
     public void contextInitialized(ServletContextEvent sce) {
         ServletContext ctx = sce.getServletContext();
+        initDatabaseConnector(ctx);
         initUserDao(ctx);
         initUserService(ctx);
         initArticleDao(ctx);
         initArticleService(ctx);
     }
 
+    private void initDatabaseConnector(ServletContext ctx) {
+        ctx.setAttribute("databaseConnector", new MysqlConnector());
+    }
+
     private void initUserDao(ServletContext ctx) {
-        ctx.setAttribute("userDao", new UserDao());
+        ctx.setAttribute("userDao", new UserDao((DatabaseConnector) ctx.getAttribute("databaseConnector")));
     }
 
     private void initUserService(ServletContext ctx) {
@@ -29,7 +36,7 @@ public class AppContextListener implements ServletContextListener {
     }
 
     private void initArticleDao(ServletContext ctx) {
-        ctx.setAttribute("articleDao", new ArticleDao());
+        ctx.setAttribute("userDao", new UserDao((DatabaseConnector) ctx.getAttribute("databaseConnector")));
     }
 
     private void initArticleService(ServletContext ctx) {

--- a/src/main/java/com/jspcafe/container/AppContextListener.java
+++ b/src/main/java/com/jspcafe/container/AppContextListener.java
@@ -36,7 +36,7 @@ public class AppContextListener implements ServletContextListener {
     }
 
     private void initArticleDao(ServletContext ctx) {
-        ctx.setAttribute("userDao", new UserDao((DatabaseConnector) ctx.getAttribute("databaseConnector")));
+        ctx.setAttribute("articleDao", new ArticleDao((DatabaseConnector) ctx.getAttribute("databaseConnector")));
     }
 
     private void initArticleService(ServletContext ctx) {

--- a/src/main/java/com/jspcafe/user/controller/UserController.java
+++ b/src/main/java/com/jspcafe/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.jspcafe.user.controller;
 import com.jspcafe.user.model.User;
 import com.jspcafe.user.service.UserService;
 import com.jspcafe.util.HttpUtils;
+import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.annotation.WebServlet;
@@ -19,8 +20,8 @@ public class UserController extends HttpServlet {
     private UserService userService;
 
     @Override
-    public void init() throws ServletException {
-        ServletContext ctx = getServletContext();
+    public void init(ServletConfig config) {
+        ServletContext ctx = config.getServletContext();
         userService = (UserService) ctx.getAttribute("userService");
     }
 

--- a/src/main/java/com/jspcafe/user/model/UserDao.java
+++ b/src/main/java/com/jspcafe/user/model/UserDao.java
@@ -3,7 +3,9 @@ package com.jspcafe.user.model;
 import com.jspcafe.util.DatabaseConnector;
 
 import java.sql.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 public class UserDao {
     private final DatabaseConnector databaseConnector;

--- a/src/main/java/com/jspcafe/user/model/UserDao.java
+++ b/src/main/java/com/jspcafe/user/model/UserDao.java
@@ -1,15 +1,20 @@
 package com.jspcafe.user.model;
 
-import com.jspcafe.util.DBManager;
+import com.jspcafe.util.DatabaseConnector;
 
 import java.sql.*;
 import java.util.*;
 
 public class UserDao {
+    private final DatabaseConnector databaseConnector;
+
+    public UserDao(final DatabaseConnector databaseConnector) {
+        this.databaseConnector = databaseConnector;
+    }
 
     public void save(User user) {
         String sql = "INSERT INTO users (id, email, nickname, password) VALUES (?, ?, ?, ?)";
-        try (Connection conn = DBManager.getConnection();
+        try (Connection conn = databaseConnector.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
             pstmt.setString(1, user.id());
             pstmt.setString(2, user.email());
@@ -23,7 +28,7 @@ public class UserDao {
 
     public Optional<User> findById(String id) {
         String sql = "SELECT * FROM users WHERE id = ?";
-        try (Connection conn = DBManager.getConnection();
+        try (Connection conn = databaseConnector.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
             pstmt.setString(1, id);
             try (ResultSet rs = pstmt.executeQuery()) {
@@ -44,7 +49,7 @@ public class UserDao {
 
     public Optional<User> findByEmail(String email) {
         String sql = "SELECT * FROM users WHERE email = ?";
-        try (Connection conn = DBManager.getConnection();
+        try (Connection conn = databaseConnector.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
             pstmt.setString(1, email);
             try (ResultSet rs = pstmt.executeQuery()) {
@@ -66,7 +71,7 @@ public class UserDao {
     public List<User> findAll() {
         String sql = "SELECT * FROM users";
         List<User> users = new ArrayList<>();
-        try (Connection conn = DBManager.getConnection();
+        try (Connection conn = databaseConnector.getConnection();
              Statement stmt = conn.createStatement();
              ResultSet rs = stmt.executeQuery(sql)) {
             while (rs.next()) {
@@ -85,7 +90,7 @@ public class UserDao {
 
     public void update(final User updateUser) {
         String sql = "UPDATE users SET email = ?, nickname = ?, password = ? WHERE id = ?";
-        try (Connection conn = DBManager.getConnection();
+        try (Connection conn = databaseConnector.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
             pstmt.setString(1, updateUser.email());
             pstmt.setString(2, updateUser.nickname());

--- a/src/main/java/com/jspcafe/util/DBManager.java
+++ b/src/main/java/com/jspcafe/util/DBManager.java
@@ -1,0 +1,43 @@
+package com.jspcafe.util;
+
+import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class DBManager {
+    private static final String URL = "jdbc:mysql://mysql:3306/jspcafe?useSSL=false&allowPublicKeyRetrieval=true";
+    private static final String USER = "jspcafe";
+    private static final String PASSWORD = "jspcafe";
+
+    private static MysqlConnectionPoolDataSource dataSource;
+
+    static {
+        try {
+            dataSource = new MysqlConnectionPoolDataSource();
+            dataSource.setURL(URL);
+            dataSource.setUser(USER);
+            dataSource.setPassword(PASSWORD);
+
+            dataSource.setMaxReconnects(5);
+            dataSource.setInitialTimeout(2);
+            dataSource.setAutoReconnect(true);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static Connection getConnection() throws SQLException {
+        return dataSource.getConnection();
+    }
+
+    public static void closeConnection(Connection conn) {
+        if (conn != null) {
+            try {
+                conn.close();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/main/java/com/jspcafe/util/DatabaseConnector.java
+++ b/src/main/java/com/jspcafe/util/DatabaseConnector.java
@@ -1,0 +1,9 @@
+package com.jspcafe.util;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public interface DatabaseConnector {
+    Connection getConnection() throws SQLException;
+    void closeConnection(Connection conn);
+}

--- a/src/main/java/com/jspcafe/util/DatabaseConnector.java
+++ b/src/main/java/com/jspcafe/util/DatabaseConnector.java
@@ -5,5 +5,6 @@ import java.sql.SQLException;
 
 public interface DatabaseConnector {
     Connection getConnection() throws SQLException;
+
     void closeConnection(Connection conn);
 }

--- a/src/main/java/com/jspcafe/util/MysqlConnector.java
+++ b/src/main/java/com/jspcafe/util/MysqlConnector.java
@@ -5,7 +5,7 @@ import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-public class DBManager {
+public class MysqlConnector implements DatabaseConnector {
     private static final String URL = "jdbc:mysql://mysql:3306/jspcafe?useSSL=false&allowPublicKeyRetrieval=true";
     private static final String USER = "jspcafe";
     private static final String PASSWORD = "jspcafe";
@@ -27,11 +27,13 @@ public class DBManager {
         }
     }
 
-    public static Connection getConnection() throws SQLException {
+    @Override
+    public Connection getConnection() throws SQLException {
         return dataSource.getConnection();
     }
 
-    public static void closeConnection(Connection conn) {
+    @Override
+    public void closeConnection(Connection conn) {
         if (conn != null) {
             try {
                 conn.close();

--- a/src/main/java/com/jspcafe/util/MysqlConnector.java
+++ b/src/main/java/com/jspcafe/util/MysqlConnector.java
@@ -2,27 +2,37 @@ package com.jspcafe.util;
 
 import com.mysql.cj.jdbc.MysqlConnectionPoolDataSource;
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 
 public class MysqlConnector implements DatabaseConnector {
-    private static final String URL = "jdbc:mysql://mysql:3306/jspcafe?useSSL=false&allowPublicKeyRetrieval=true";
-    private static final String USER = "jspcafe";
-    private static final String PASSWORD = "jspcafe";
+    private static final String CONFIG_FILE = "config.properties";
 
     private static MysqlConnectionPoolDataSource dataSource;
 
     static {
         try {
+            Properties props = new Properties();
+            InputStream inputStream = MysqlConnector.class.getClassLoader().getResourceAsStream(CONFIG_FILE);
+            if (inputStream == null) {
+                throw new IOException("Unable to find " + CONFIG_FILE);
+            }
+            props.load(inputStream);
+
             dataSource = new MysqlConnectionPoolDataSource();
-            dataSource.setURL(URL);
-            dataSource.setUser(USER);
-            dataSource.setPassword(PASSWORD);
+            dataSource.setURL(props.getProperty("db.url"));
+            dataSource.setUser(props.getProperty("db.user"));
+            dataSource.setPassword(props.getProperty("db.password"));
 
             dataSource.setMaxReconnects(5);
             dataSource.setInitialTimeout(2);
             dataSource.setAutoReconnect(true);
-        } catch (SQLException e) {
+        } catch (SQLException | IOException e) {
             e.printStackTrace();
         }
     }

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,0 +1,26 @@
+USE jspcafe;
+
+CREATE TABLE IF NOT EXISTS users (
+    id VARCHAR(36) PRIMARY KEY,
+    email VARCHAR(100) NOT NULL UNIQUE,
+    nickname VARCHAR(50) NOT NULL,
+    password VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS articles (
+    id VARCHAR(36) PRIMARY KEY,
+    title VARCHAR(200) NOT NULL,
+    nickname VARCHAR(50),
+    content TEXT NOT NULL,
+    create_at TIMESTAMP NOT NULL
+);
+
+INSERT INTO users (id, email, nickname, password)
+VALUES ('550e8400-e29b-41d4-a716-446655440000', 'user1@example.com', 'User1', 'hashed_password_1'),
+('550e8400-e29b-41d4-a716-446655440001', 'user2@example.com', 'User2', 'hashed_password_2'),
+('550e8400-e29b-41d4-a716-446655440002', 'user3@example.com', 'User3', 'hashed_password_3');
+
+INSERT INTO articles (id, title, nickname, content, create_at)
+VALUES ('550e8400-e29b-41d4-a716-446655440003', 'First Article', 'User1', 'This is the content of the first article.', '2023-07-24 10:00:00'),
+       ('550e8400-e29b-41d4-a716-446655440004', 'Second Article', 'User2', 'This is the content of the second article.', '2023-07-24 11:00:00'),
+       ('550e8400-e29b-41d4-a716-446655440005', 'Third Article', 'User3', 'This is the content of the third article.', '2023-07-24 12:00:00');

--- a/src/test/java/com/jspcafe/board/controller/ArticleControllerTest.java
+++ b/src/test/java/com/jspcafe/board/controller/ArticleControllerTest.java
@@ -1,0 +1,110 @@
+package com.jspcafe.board.controller;
+
+import com.jspcafe.board.model.Article;
+import com.jspcafe.board.service.ArticleService;
+import com.jspcafe.board.model.ArticleDao;
+import com.jspcafe.test_util.*;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArticleControllerTest {
+    private ArticleController articleController;
+    private StubHttpServletRequest request;
+    private StubHttpServletResponse response;
+    private StubServletContext servletContext;
+    private ArticleDao articleDao;
+    private ArticleService articleService;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        articleController = new ArticleController();
+        request = new StubHttpServletRequest();
+        response = new StubHttpServletResponse();
+        servletContext = new StubServletContext();
+
+        H2Initializer.initializeDatabase(H2Connector.INSTANCE);
+        articleDao = new ArticleDao(H2Connector.INSTANCE);
+        articleService = new ArticleService(articleDao);
+        servletContext.setAttribute("articleService", articleService);
+
+        articleController.init(new StubServletConfig(servletContext));
+    }
+
+    @Test
+    void 게시글_목록을_조회할_수_있다() throws ServletException, IOException {
+        // Given
+        List<Article> articles = Arrays.asList(
+                Article.create("제목1", "작성자1", "내용1"),
+                Article.create("제목2", "작성자2", "내용2")
+        );
+        for (Article article : articles) {
+            articleDao.save(article);
+        }
+
+        request.setPathInfo(null);
+
+        // When
+        articleController.doGet(request, response);
+        List<Article> result = (List<Article>) request.getAttribute("articles");
+
+        // Then
+        assertEquals("/WEB-INF/views/board/board.jsp", request.getForwardedPath());
+        assertEquals(articles.size(), result.size());
+    }
+
+    @Test
+    void 특정_게시글을_조회할_수_있다() throws ServletException, IOException {
+        // Given
+        Article article = Article.create("테스트 제목", "테스트 작성자", "테스트 내용");
+        articleDao.save(article);
+
+        request.setPathInfo("/" + article.id());
+
+        // When
+        articleController.doGet(request, response);
+
+        // Then
+        assertEquals("/WEB-INF/views/board/article_detail.jsp", request.getForwardedPath());
+        assertEquals(article, request.getAttribute("article"));
+    }
+
+    @Test
+    void 새_게시글을_작성할_수_있다() throws ServletException, IOException {
+        // Given
+        request.setParameter("title", "새 게시글");
+        request.setParameter("nickname", "새 작성자");
+        request.setParameter("content", "새 내용");
+
+        // When
+        articleController.doPost(request, response);
+
+        // Then
+        List<Article> articles = articleService.findAll();
+        assertEquals(1, articles.size());
+        Article newArticle = articles.get(0);
+        assertEquals("새 게시글", newArticle.title());
+        assertEquals("새 작성자", newArticle.nickname());
+        assertEquals("새 내용", newArticle.content());
+        assertEquals("/", response.getRedirectLocation());
+    }
+
+    @Test
+    void 게시글_작성_폼을_조회할_수_있다() throws ServletException, IOException {
+        // Given
+        request.setPathInfo("/form");
+
+        // When
+        articleController.doGet(request, response);
+
+        // Then
+        assertEquals("/WEB-INF/views/board/article_form.jsp", request.getForwardedPath());
+    }
+}

--- a/src/test/java/com/jspcafe/board/model/ArticleDaoTest.java
+++ b/src/test/java/com/jspcafe/board/model/ArticleDaoTest.java
@@ -1,8 +1,14 @@
 package com.jspcafe.board.model;
 
 import com.jspcafe.exception.ArticleNotFoundException;
+import com.jspcafe.test_util.H2Connector;
+import com.jspcafe.test_util.H2Initializer;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -11,7 +17,8 @@ class ArticleDaoTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        articleDao = new ArticleDao();
+        H2Initializer.initializeDatabase(H2Connector.INSTANCE);
+        articleDao = new ArticleDao(H2Connector.INSTANCE);
     }
 
     @Test

--- a/src/test/java/com/jspcafe/board/service/ArticleServiceTest.java
+++ b/src/test/java/com/jspcafe/board/service/ArticleServiceTest.java
@@ -3,6 +3,8 @@ package com.jspcafe.board.service;
 import com.jspcafe.board.model.Article;
 import com.jspcafe.board.model.ArticleDao;
 import com.jspcafe.exception.ArticleNotFoundException;
+import com.jspcafe.test_util.H2Connector;
+import com.jspcafe.test_util.H2Initializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +19,8 @@ class ArticleServiceTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        articleDao = new ArticleDao();
+        H2Initializer.initializeDatabase(H2Connector.INSTANCE);
+        articleDao = new ArticleDao(H2Connector.INSTANCE);
         articleService = new ArticleService(articleDao);
     }
 

--- a/src/test/java/com/jspcafe/test_util/H2Connector.java
+++ b/src/test/java/com/jspcafe/test_util/H2Connector.java
@@ -1,0 +1,37 @@
+package com.jspcafe.test_util;
+
+import com.jspcafe.util.DatabaseConnector;
+
+import org.h2.jdbcx.JdbcConnectionPool;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class H2Connector implements DatabaseConnector {
+    public static final DatabaseConnector INSTANCE = new H2Connector();
+    private static final String URL = "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1";
+    private static final String USER = "sa";
+    private static final String PASSWORD = "";
+
+    private final JdbcConnectionPool connectionPool;
+
+    public H2Connector() {
+        connectionPool = JdbcConnectionPool.create(URL, USER, PASSWORD);
+        connectionPool.setMaxConnections(10);
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return connectionPool.getConnection();
+    }
+
+    @Override
+    public void closeConnection(Connection conn) {
+        if (conn != null) {
+            try {
+                conn.close();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/src/test/java/com/jspcafe/test_util/H2Initializer.java
+++ b/src/test/java/com/jspcafe/test_util/H2Initializer.java
@@ -1,0 +1,19 @@
+package com.jspcafe.test_util;
+
+import com.jspcafe.util.DatabaseConnector;
+import org.h2.tools.RunScript;
+import java.io.FileReader;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public class H2Initializer {
+    private static final String INIT_SCRIPT_PATH = "src/test/resources/init.sql";
+
+    public static void initializeDatabase(DatabaseConnector dataBaseConnector) throws SQLException {
+        try(Connection connection = dataBaseConnector.getConnection()) {
+            RunScript.execute(connection, new FileReader(INIT_SCRIPT_PATH));
+        } catch (Exception e) {
+            throw new SQLException("Failed to initialize H2 database", e);
+        }
+    }
+}

--- a/src/test/java/com/jspcafe/test_util/StubHttpServletRequest.java
+++ b/src/test/java/com/jspcafe/test_util/StubHttpServletRequest.java
@@ -10,6 +10,7 @@ import java.util.*;
 public class StubHttpServletRequest implements HttpServletRequest {
     private String body;
     private String pathInfo;
+    private String forwardedPath;
     private final Map<String, String> parameters = new HashMap<>();
     private final Map<String, Object> attributes = new HashMap<>();
 
@@ -81,8 +82,22 @@ public class StubHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
-    public RequestDispatcher getRequestDispatcher(String s) {
-        return null;
+    public RequestDispatcher getRequestDispatcher(String path) {
+        return new RequestDispatcher() {
+            @Override
+            public void forward(ServletRequest request, ServletResponse response) {
+                forwardedPath = path;
+            }
+
+            @Override
+            public void include(ServletRequest request, ServletResponse response) {
+                // 구현 필요 없음
+            }
+        };
+    }
+
+    public String getForwardedPath() {
+        return forwardedPath;
     }
 
     @Override

--- a/src/test/java/com/jspcafe/test_util/StubHttpServletRequest.java
+++ b/src/test/java/com/jspcafe/test_util/StubHttpServletRequest.java
@@ -1,4 +1,4 @@
-package com.jspcafe.util;
+package com.jspcafe.test_util;
 
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;

--- a/src/test/java/com/jspcafe/test_util/StubHttpServletRequest.java
+++ b/src/test/java/com/jspcafe/test_util/StubHttpServletRequest.java
@@ -13,10 +13,6 @@ public class StubHttpServletRequest implements HttpServletRequest {
     private final Map<String, String> parameters = new HashMap<>();
     private final Map<String, Object> attributes = new HashMap<>();
 
-    public StubHttpServletRequest(String body) {
-        this.body = body;
-    }
-
     @Override
     public BufferedReader getReader() throws IOException {
         return new BufferedReader(new StringReader(body));

--- a/src/test/java/com/jspcafe/test_util/StubHttpServletRequest.java
+++ b/src/test/java/com/jspcafe/test_util/StubHttpServletRequest.java
@@ -8,7 +8,10 @@ import java.security.Principal;
 import java.util.*;
 
 public class StubHttpServletRequest implements HttpServletRequest {
-    private final String body;
+    private String body;
+    private String pathInfo;
+    private final Map<String, String> parameters = new HashMap<>();
+    private final Map<String, Object> attributes = new HashMap<>();
 
     public StubHttpServletRequest(String body) {
         this.body = body;
@@ -19,6 +22,38 @@ public class StubHttpServletRequest implements HttpServletRequest {
         return new BufferedReader(new StringReader(body));
     }
 
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public void setPathInfo(String pathInfo) {
+        this.pathInfo = pathInfo;
+    }
+
+    public void setParameter(String name, String value) {
+        parameters.put(name, value);
+    }
+
+    @Override
+    public String getPathInfo() {
+        return pathInfo;
+    }
+
+    @Override
+    public String getParameter(String name) {
+        return parameters.get(name);
+    }
+
+    @Override
+    public void setAttribute(String name, Object value) {
+        attributes.put(name, value);
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return attributes.get(name);
+    }
+
     @Override
     public String getRemoteAddr() {
         return "";
@@ -27,11 +62,6 @@ public class StubHttpServletRequest implements HttpServletRequest {
     @Override
     public String getRemoteHost() {
         return "";
-    }
-
-    @Override
-    public void setAttribute(String s, Object o) {
-
     }
 
     @Override
@@ -130,11 +160,6 @@ public class StubHttpServletRequest implements HttpServletRequest {
     }
 
     @Override
-    public Object getAttribute(String s) {
-        return null;
-    }
-
-    @Override
     public Enumeration<String> getAttributeNames() {
         return null;
     }
@@ -187,13 +212,7 @@ public class StubHttpServletRequest implements HttpServletRequest {
             public int read() throws IOException {
                 return inputStream.read();
             }
-            // 여기에 필요한 다른 메서드들을 구현...
         };
-    }
-
-    @Override
-    public String getParameter(String s) {
-        return "";
     }
 
     @Override
@@ -268,11 +287,6 @@ public class StubHttpServletRequest implements HttpServletRequest {
 
     @Override
     public String getMethod() {
-        return "";
-    }
-
-    @Override
-    public String getPathInfo() {
         return "";
     }
 

--- a/src/test/java/com/jspcafe/test_util/StubHttpServletResponse.java
+++ b/src/test/java/com/jspcafe/test_util/StubHttpServletResponse.java
@@ -1,0 +1,198 @@
+package com.jspcafe.test_util;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.*;
+
+public class StubHttpServletResponse implements HttpServletResponse {
+    private int status;
+    private final Map<String, String> headers = new HashMap<>();
+    private String redirectLocation;
+    private String forwardPath;
+
+    @Override
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public void setHeader(String name, String value) {
+        headers.put(name, value);
+    }
+
+    public String getRedirectLocation() {
+        return redirectLocation;
+    }
+
+    public void setForwardPath(String path) {
+        this.forwardPath = path;
+    }
+
+    public String getForwardPath() {
+        return forwardPath;
+    }
+
+    @Override
+    public String getHeader(String name) {
+        return headers.get(name);
+    }
+
+    @Override
+    public void sendRedirect(String location) {
+        this.redirectLocation = location;
+    }
+
+    @Override
+    public void addHeader(String s, String s1) {
+
+    }
+
+    @Override
+    public void setIntHeader(String s, int i) {
+
+    }
+
+    @Override
+    public void addIntHeader(String s, int i) {
+
+    }
+
+    @Override
+    public Collection<String> getHeaders(String s) {
+        return List.of();
+    }
+
+    @Override
+    public Collection<String> getHeaderNames() {
+        return List.of();
+    }
+
+    @Override
+    public void addCookie(Cookie cookie) {
+
+    }
+
+    @Override
+    public boolean containsHeader(String s) {
+        return false;
+    }
+
+    @Override
+    public String encodeURL(String s) {
+        return "";
+    }
+
+    @Override
+    public String encodeRedirectURL(String s) {
+        return "";
+    }
+
+    @Override
+    public void sendError(int i, String s) throws IOException {
+
+    }
+
+    @Override
+    public void sendError(int i) throws IOException {
+
+    }
+
+    @Override
+    public void setDateHeader(String s, long l) {
+
+    }
+
+    @Override
+    public void addDateHeader(String s, long l) {
+
+    }
+
+    @Override
+    public String getCharacterEncoding() {
+        return "";
+    }
+
+    @Override
+    public String getContentType() {
+        return "";
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        return null;
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        return null;
+    }
+
+    @Override
+    public void setCharacterEncoding(String s) {
+
+    }
+
+    @Override
+    public void setContentLength(int i) {
+
+    }
+
+    @Override
+    public void setContentLengthLong(long l) {
+
+    }
+
+    @Override
+    public void setContentType(String s) {
+
+    }
+
+    @Override
+    public void setBufferSize(int i) {
+
+    }
+
+    @Override
+    public int getBufferSize() {
+        return 0;
+    }
+
+    @Override
+    public void flushBuffer() throws IOException {
+
+    }
+
+    @Override
+    public void resetBuffer() {
+
+    }
+
+    @Override
+    public boolean isCommitted() {
+        return false;
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public void setLocale(Locale locale) {
+
+    }
+
+    @Override
+    public Locale getLocale() {
+        return null;
+    }
+}

--- a/src/test/java/com/jspcafe/test_util/StubServletConfig.java
+++ b/src/test/java/com/jspcafe/test_util/StubServletConfig.java
@@ -1,0 +1,35 @@
+package com.jspcafe.test_util;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+
+import java.util.Collections;
+import java.util.Enumeration;
+
+public class StubServletConfig implements ServletConfig {
+    private final ServletContext servletContext;
+
+    public StubServletConfig(ServletContext servletContext) {
+        this.servletContext = servletContext;
+    }
+
+    @Override
+    public String getServletName() {
+        return "TestServlet";
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        return servletContext;
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+        return null;
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+        return Collections.emptyEnumeration();
+    }
+}

--- a/src/test/java/com/jspcafe/test_util/StubServletContext.java
+++ b/src/test/java/com/jspcafe/test_util/StubServletContext.java
@@ -1,0 +1,287 @@
+package com.jspcafe.test_util;
+
+import jakarta.servlet.*;
+import jakarta.servlet.descriptor.JspConfigDescriptor;
+
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.*;
+
+public class StubServletContext implements ServletContext {
+    private final Map<String, Object> attributes = new HashMap<>();
+
+    @Override
+    public void setAttribute(String name, Object object) {
+        attributes.put(name, object);
+    }
+
+    @Override
+    public void removeAttribute(String s) {
+    }
+
+    @Override
+    public String getServletContextName() {
+        return "";
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addServlet(String s, String s1) {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addServlet(String s, Servlet servlet) {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addServlet(String s, Class<? extends Servlet> aClass) {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration.Dynamic addJspFile(String s, String s1) {
+        return null;
+    }
+
+    @Override
+    public <T extends Servlet> T createServlet(Class<T> aClass) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration getServletRegistration(String s) {
+        return null;
+    }
+
+    @Override
+    public Map<String, ? extends ServletRegistration> getServletRegistrations() {
+        return Map.of();
+    }
+
+    @Override
+    public FilterRegistration.Dynamic addFilter(String s, String s1) {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration.Dynamic addFilter(String s, Filter filter) {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration.Dynamic addFilter(String s, Class<? extends Filter> aClass) {
+        return null;
+    }
+
+    @Override
+    public <T extends Filter> T createFilter(Class<T> aClass) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration getFilterRegistration(String s) {
+        return null;
+    }
+
+    @Override
+    public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
+        return Map.of();
+    }
+
+    @Override
+    public SessionCookieConfig getSessionCookieConfig() {
+        return null;
+    }
+
+    @Override
+    public void setSessionTrackingModes(Set<SessionTrackingMode> set) {
+
+    }
+
+    @Override
+    public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
+        return Set.of();
+    }
+
+    @Override
+    public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
+        return Set.of();
+    }
+
+    @Override
+    public void addListener(String s) {
+
+    }
+
+    @Override
+    public <T extends EventListener> void addListener(T t) {
+
+    }
+
+    @Override
+    public void addListener(Class<? extends EventListener> aClass) {
+
+    }
+
+    @Override
+    public <T extends EventListener> T createListener(Class<T> aClass) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public JspConfigDescriptor getJspConfigDescriptor() {
+        return null;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return null;
+    }
+
+    @Override
+    public void declareRoles(String... strings) {
+
+    }
+
+    @Override
+    public String getVirtualServerName() {
+        return "";
+    }
+
+    @Override
+    public int getSessionTimeout() {
+        return 0;
+    }
+
+    @Override
+    public void setSessionTimeout(int i) {
+
+    }
+
+    @Override
+    public String getRequestCharacterEncoding() {
+        return "";
+    }
+
+    @Override
+    public void setRequestCharacterEncoding(String s) {
+
+    }
+
+    @Override
+    public String getResponseCharacterEncoding() {
+        return "";
+    }
+
+    @Override
+    public void setResponseCharacterEncoding(String s) {
+
+    }
+
+    @Override
+    public String getContextPath() {
+        return "";
+    }
+
+    @Override
+    public ServletContext getContext(String s) {
+        return null;
+    }
+
+    @Override
+    public int getMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getEffectiveMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getEffectiveMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public String getMimeType(String s) {
+        return "";
+    }
+
+    @Override
+    public Set<String> getResourcePaths(String s) {
+        return Set.of();
+    }
+
+    @Override
+    public URL getResource(String s) throws MalformedURLException {
+        return null;
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String s) {
+        return null;
+    }
+
+    @Override
+    public RequestDispatcher getRequestDispatcher(String s) {
+        return null;
+    }
+
+    @Override
+    public RequestDispatcher getNamedDispatcher(String s) {
+        return null;
+    }
+
+    @Override
+    public void log(String s) {
+
+    }
+
+    @Override
+    public void log(String s, Throwable throwable) {
+
+    }
+
+    @Override
+    public String getRealPath(String s) {
+        return "";
+    }
+
+    @Override
+    public String getServerInfo() {
+        return "";
+    }
+
+    @Override
+    public String getInitParameter(String s) {
+        return "";
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+        return null;
+    }
+
+    @Override
+    public boolean setInitParameter(String s, String s1) {
+        return false;
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return attributes.get(name);
+    }
+
+    @Override
+    public Enumeration<String> getAttributeNames() {
+        return null;
+    }
+}

--- a/src/test/java/com/jspcafe/user/controller/UserControllerTest.java
+++ b/src/test/java/com/jspcafe/user/controller/UserControllerTest.java
@@ -1,0 +1,118 @@
+package com.jspcafe.user.controller;
+
+import com.jspcafe.exception.UserNotFoundException;
+import com.jspcafe.test_util.*;
+import com.jspcafe.user.model.User;
+import com.jspcafe.user.model.UserDao;
+import com.jspcafe.user.service.UserService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserControllerTest {
+    private UserController userController;
+    private StubHttpServletRequest request;
+    private StubHttpServletResponse response;
+    private StubServletContext servletContext;
+    private UserDao userDao;
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        userController = new UserController();
+        request = new StubHttpServletRequest();
+        response = new StubHttpServletResponse();
+        servletContext = new StubServletContext();
+
+        H2Initializer.initializeDatabase(H2Connector.INSTANCE);
+        userDao = new UserDao(H2Connector.INSTANCE);
+        userService = new UserService(userDao);
+        servletContext.setAttribute("userService", userService);
+
+        userController.init(new StubServletConfig(servletContext));
+    }
+
+    @Test
+    void 사용자_목록을_조회할_수_있다() throws ServletException, IOException {
+        // Given
+        List<User> users = Arrays.asList(
+                new User("1", "user1@example.com", "사용자1", "password1"),
+                new User("2", "user2@example.com", "사용자2", "password2")
+        );
+        for (User user : users) {
+            userDao.save(user);
+        }
+
+        request.setPathInfo(null);
+
+        // When
+        userController.doGet(request, response);
+
+        // Then
+        assertEquals("/WEB-INF/views/user/user_list.jsp", request.getForwardedPath());
+        assertEquals(users, request.getAttribute("users"));
+    }
+
+    @Test
+    void 특정_사용자의_프로필을_조회할_수_있다() throws ServletException, IOException {
+        // Given
+        User user = new User("1", "user1@example.com", "사용자1", "password1");
+        userDao.save(user);
+
+        request.setPathInfo("/1");
+
+        // When
+        userController.doGet(request, response);
+
+        // Then
+        assertEquals("/WEB-INF/views/user/user_profile.jsp", request.getForwardedPath());
+        assertEquals(user, request.getAttribute("user"));
+    }
+
+    @Test
+    void 새로운_사용자를_등록할_수_있다() throws ServletException, IOException {
+        // Given
+        request.setParameter("email", "newuser@example.com");
+        request.setParameter("nickname", "새사용자");
+        request.setParameter("password", "password123");
+
+        // When
+        userController.doPost(request, response);
+
+        // Then
+        User newUser = userDao.findByEmail("newuser@example.com")
+                .orElseThrow(() -> new UserNotFoundException("User email not found"));
+        assertNotNull(newUser);
+        assertEquals("새사용자", newUser.nickname());
+        assertEquals("/users", response.getRedirectLocation());
+    }
+
+    @Test
+    void 사용자_프로필을_업데이트할_수_있다() throws ServletException, IOException {
+        // Given
+        User user = User.create("user1@example.com", "사용자1", "password1");
+        userDao.save(user);
+
+        request.setPathInfo("/" + user.id());
+        request.setBody("{\"currentPassword\":\"password1\",\"email\":\"updated@example.com\",\"nickname\":\"업데이트된사용자\",\"newPassword\":\"newpassword123\"}");
+
+        // When
+        userController.doPut(request, response);
+
+        // Then
+        User updatedUser = userDao.findById(user.id())
+                .orElseThrow(() -> new UserNotFoundException("User id not found"));
+        assertEquals("updated@example.com", updatedUser.email());
+        assertEquals("업데이트된사용자", updatedUser.nickname());
+        assertEquals(HttpServletResponse.SC_SEE_OTHER, response.getStatus());
+        assertEquals("/users/" + user.id(), response.getHeader("Location"));
+    }
+}

--- a/src/test/java/com/jspcafe/user/model/UserDaoTest.java
+++ b/src/test/java/com/jspcafe/user/model/UserDaoTest.java
@@ -1,9 +1,12 @@
 package com.jspcafe.user.model;
 
 import com.jspcafe.exception.UserNotFoundException;
+import com.jspcafe.test_util.H2Connector;
+import com.jspcafe.test_util.H2Initializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.sql.SQLException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -12,8 +15,9 @@ class UserDaoTest {
     private UserDao userDao;
 
     @BeforeEach
-    void setUp() {
-        userDao = new UserDao();
+    void setUp() throws SQLException {
+        H2Initializer.initializeDatabase(H2Connector.INSTANCE);
+        userDao = new UserDao(H2Connector.INSTANCE);
     }
 
     @Test

--- a/src/test/java/com/jspcafe/user/service/UserServiceTest.java
+++ b/src/test/java/com/jspcafe/user/service/UserServiceTest.java
@@ -1,11 +1,14 @@
 package com.jspcafe.user.service;
 
 import com.jspcafe.exception.UserNotFoundException;
+import com.jspcafe.test_util.H2Connector;
+import com.jspcafe.test_util.H2Initializer;
 import com.jspcafe.user.model.User;
 import com.jspcafe.user.model.UserDao;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.sql.SQLException;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -15,8 +18,9 @@ class UserServiceTest {
     private UserDao userDao;
 
     @BeforeEach
-    void setUp() {
-        userDao = new UserDao();
+    void setUp() throws SQLException {
+        H2Initializer.initializeDatabase(H2Connector.INSTANCE);
+        userDao = new UserDao(H2Connector.INSTANCE);
         userService = new UserService(userDao);
     }
 

--- a/src/test/java/com/jspcafe/util/HttpUtilsTest.java
+++ b/src/test/java/com/jspcafe/util/HttpUtilsTest.java
@@ -1,5 +1,6 @@
 package com.jspcafe.util;
 
+import com.jspcafe.test_util.StubHttpServletRequest;
 import jakarta.servlet.http.*;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/jspcafe/util/HttpUtilsTest.java
+++ b/src/test/java/com/jspcafe/util/HttpUtilsTest.java
@@ -15,7 +15,8 @@ public class HttpUtilsTest {
     void HttpRequest_body_내용을_정상적으로_반환한다() throws IOException {
         // Given
         String expectedBody = "This is the request body";
-        HttpServletRequest request = new StubHttpServletRequest(expectedBody);
+        StubHttpServletRequest request = new StubHttpServletRequest();
+        request.setBody(expectedBody);
 
         // When
         String actualBody = HttpUtils.readRequestBody(request);
@@ -28,7 +29,8 @@ public class HttpUtilsTest {
     void JSON_형식의_요청_본문을_Map으로_변환한다() throws IOException {
         // Given
         String jsonBody = "{\"name\":\"John Doe\",\"age\":30,\"city\":\"New York\"}";
-        HttpServletRequest request = new StubHttpServletRequest(jsonBody);
+        StubHttpServletRequest request = new StubHttpServletRequest();
+        request.setBody(jsonBody);
 
         // When
         Map<String, Object> result = HttpUtils.getJsonRequestBody(request);

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -1,0 +1,20 @@
+DROP TABLE IF EXISTS articles;
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE users (
+    id VARCHAR(36) PRIMARY KEY,
+    email VARCHAR(100) NOT NULL UNIQUE,
+    nickname VARCHAR(50) NOT NULL,
+    password VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE articles (
+    id VARCHAR(36) PRIMARY KEY,
+    title VARCHAR(200) NOT NULL,
+    nickname VARCHAR(50),
+    content CLOB NOT NULL,
+    create_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX idx_articles_nickname ON articles(nickname);
+CREATE INDEX idx_articles_create_at ON articles(create_at);


### PR DESCRIPTION
## 구현 내용
[기능]
- MySQL 데이터베이스 연동
  - JDBC드라이버를 이용해 MySQL 데이터베이스와 연동
  - MySQL은 8.x를 사용
- 게시글 데이터 저장하기
  - Article 클래스를 DB테이블에 저장할 수 있게 구현
  - Article 테이블이 적절한 PK를 가지도록 구현한
- 게시글 목록 구현
  - 전체 게시글 목록 데이터를 DB에서 조회하도록 구현
- 게시글 상세보기 구현
  - 게시글의 세부 내용을 DB에서 가져온다.
- 사용자 정보 DB에 저장
  - 회원가입을 통해 등록한 사용자 정보를 DB에 저장
- 배포
  - EC2로 간단하게 배포를 진행

## 고민 사항
- 실제 운영환경에서는 MySQL을 사용합니다.
- 테스트에서는 원활한 테스트를 위해 인메모리 H2를 사용합니다.
- 원활한 배포를 위해 도커를 사용하였습니다.

## 기타
테크 스펙
https://docs.google.com/document/d/1kP-xtYlmY5_-NAlQetA6UCAgCyhRBrLWRV44c95FSO8/edit?usp=sharing