### PR TITLE
[김수현] step-2 글 쓰기 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     implementation 'org.glassfish.web:jakarta.servlet.jsp.jstl:3.0.1'
     implementation 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.0'
 
+    implementation 'mysql:mysql-connector-java:8.0.33'
+
     implementation 'ch.qos.logback:logback-classic:1.4.12'
     // test - embed tomcat
     testImplementation 'org.apache.tomcat.embed:tomcat-embed-core:10.0.23'

--- a/src/main/java/com/codesquad/cafe/db/InMemoryUserRepository.java
+++ b/src/main/java/com/codesquad/cafe/db/InMemoryUserRepository.java
@@ -24,7 +24,6 @@ public class InMemoryUserRepository implements UserRepository {
 
     @Override
     public User save(User user) {
-
         findByUsername(user.getUsername()).ifPresent(existUser -> {
             log.debug("unique constraint violated: {}", user.getUsername());
             throw new IllegalArgumentException("이미 존재하는 username 입니다.");
@@ -37,7 +36,7 @@ public class InMemoryUserRepository implements UserRepository {
 
     @Override
     public Optional<User> findById(Long id) {
-        return Optional.ofNullable(users.get(id));
+        return Optional.ofNullable(users.getOrDefault(id, null));
     }
 
     @Override

--- a/src/main/java/com/codesquad/cafe/db/InMemoryUserRepository.java
+++ b/src/main/java/com/codesquad/cafe/db/InMemoryUserRepository.java
@@ -24,11 +24,29 @@ public class InMemoryUserRepository implements UserRepository {
 
     @Override
     public User save(User user) {
+        if (user.getId() != null) {
+            return update(user);
+        } else {
+            return create(user);
+        }
+    }
+
+    private User update(User user) {
+        if (user.getId() == null) {
+            throw new IllegalArgumentException("존재하지 않는 user 입니다.");
+        }
+        users.put(user.getId(), user);
+        return user;
+    }
+
+    private User create(User user) {
+        if (user.getId() != null) {
+            throw new IllegalArgumentException("이미 존재하는 user 입니다.");
+        }
         findByUsername(user.getUsername()).ifPresent(existUser -> {
             log.debug("unique constraint violated: {}", user.getUsername());
             throw new IllegalArgumentException("이미 존재하는 username 입니다.");
         });
-
         user.setId(seq.getAndIncrement());
         users.put(user.getId(), user);
         return user;

--- a/src/main/java/com/codesquad/cafe/model/Post.java
+++ b/src/main/java/com/codesquad/cafe/model/Post.java
@@ -1,34 +1,42 @@
 package com.codesquad.cafe.model;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 public class Post {
+
     private Long id;
-    private Long userId;
+
+    private Long authorId;
+
     private String title;
+
     private String content;
+
     private String fileName;
+
     private int view;
+
     private LocalDateTime createdAt;
 
     public Post() {
     }
 
-    public Post(Long userId, String title, String contents, String fileName) {
-        this.id = null;
-        this.userId = userId;
-        this.title = title;
-        this.content = contents;
-        this.fileName = fileName;
-        this.view = 0;
-        this.createdAt = LocalDateTime.now();
-    }
-
-    public Post(Long id, Long userId, String title, String content, String fileName, int view,
+    public Post(Long id, Long authorId, String title, String content, String fileName, int view,
                 LocalDateTime createdAt) {
+        if (authorId == null || authorId < 1) {
+            throw new IllegalArgumentException("authorId는 1 이상의 값이어야 합니다.");
+        }
+        if (title == null || title.isBlank()) {
+            throw new IllegalArgumentException("title 필수 값입니다.");
+        }
+        if (content == null || content.isEmpty()) {
+            throw new IllegalArgumentException("content 필수 값입니다.");
+        }
+        if (view < 0) {
+            throw new IllegalArgumentException("view 는 0이상이어야 합니다.");
+        }
         this.id = id;
-        this.userId = userId;
+        this.authorId = authorId;
         this.title = title;
         this.content = content;
         this.view = view;
@@ -36,12 +44,17 @@ public class Post {
         this.createdAt = createdAt;
     }
 
+    public static Post of(Long authorId, String title, String content, String fileName) {
+        return new Post(null, authorId, title, content, fileName, 0, LocalDateTime.now());
+    }
+
+
     public Long getId() {
         return id;
     }
 
-    public Long getUserId() {
-        return userId;
+    public Long getAuthorId() {
+        return authorId;
     }
 
     public String getTitle() {
@@ -80,7 +93,7 @@ public class Post {
     public String toString() {
         final StringBuilder sb = new StringBuilder("Post{");
         sb.append("id=").append(id);
-        sb.append(", userId=").append(userId);
+        sb.append(", userId=").append(authorId);
         sb.append(", title='").append(title).append('\'');
         sb.append(", content='").append(content).append('\'');
         sb.append(", filename='").append(fileName).append('\'');

--- a/src/main/java/com/codesquad/cafe/model/PostCreateRequest.java
+++ b/src/main/java/com/codesquad/cafe/model/PostCreateRequest.java
@@ -1,0 +1,24 @@
+package com.codesquad.cafe.model;
+
+public class PostCreateRequest {
+    private Long authorId;
+    private String title;
+    private String content;
+
+
+    public Long getAuthorId() {
+        return authorId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Post toPost() {
+        return Post.of(authorId, title, content, null);
+    }
+}

--- a/src/main/java/com/codesquad/cafe/model/PostDetailsDto.java
+++ b/src/main/java/com/codesquad/cafe/model/PostDetailsDto.java
@@ -37,6 +37,16 @@ public class PostDetailsDto {
         this.createdAt = createdAt;
     }
 
+    public PostDetailsDto(Post post, User user) {
+        this.postId = post.getId();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.fileName = post.getFileName();
+        this.authorId = post.getAuthorId();
+        this.authorUsername = user.getUsername();
+        this.createdAt = post.getCreatedAt();
+    }
+
     public String getFormattedDate() {
         return createdAt.format(formatter);
     }

--- a/src/main/java/com/codesquad/cafe/model/User.java
+++ b/src/main/java/com/codesquad/cafe/model/User.java
@@ -3,18 +3,28 @@ package com.codesquad.cafe.model;
 import java.time.LocalDateTime;
 
 public class User {
+
     private Long id;
+
     private String username;
+
     private String password;
+
     private String name;
+
     private String email;
+
     private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private boolean deleted;
 
     public User() {
     }
 
     public User(Long id, String username, String password, String name, String email,
-                LocalDateTime createdAt) {
+                LocalDateTime createdAt, LocalDateTime updatedAt, boolean deleted) {
         if (username == null || username.isBlank()) {
             throw new IllegalArgumentException("username은 필수 값입니다.");
         }
@@ -30,16 +40,22 @@ public class User {
         if (createdAt == null || createdAt.isAfter(LocalDateTime.now())) {
             throw new IllegalArgumentException("createdAt 는 현재시간 이전이야 합니다.");
         }
+        if (updatedAt == null || updatedAt.isBefore(createdAt)) {
+            throw new IllegalArgumentException("updatedAt 은 createdAt 이후여야 합니다.");
+        }
         this.id = id;
         this.username = username;
         this.password = password;
         this.name = name;
         this.email = email;
         this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deleted = deleted;
     }
 
     public static User of(String username, String password, String name, String email) {
-        return new User(null, username, password, name, email, LocalDateTime.now());
+        LocalDateTime now = LocalDateTime.now();
+        return new User(null, username, password, name, email, now, now, false);
     }
 
     public void setId(Long id) {
@@ -70,13 +86,43 @@ public class User {
         return createdAt;
     }
 
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public void update(String password, String name, String email) {
+        if (password == null || password.isBlank()) {
+            throw new IllegalArgumentException("password 필수 값입니다.");
+        }
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("name 필수 값입니다.");
+        }
+        if (email == null || email.isEmpty()) {
+            throw new IllegalArgumentException("email 필수 값입니다.");
+        }
+        this.password = password;
+        this.name = name;
+        this.email = email;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void delete() {
+        this.deleted = true;
+        this.updatedAt = LocalDateTime.now();
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("User{");
         sb.append(", id='").append(id).append('\'');
         sb.append(", username='").append(username).append('\'');
         sb.append(", password='").append(password).append('\'');
-        sb.append(", username='").append(username).append('\'');
+        sb.append(", email='").append(email).append('\'');
+        sb.append(", isDeleted='").append(isDeleted()).append('\'');
         sb.append('}');
         return sb.toString();
     }

--- a/src/main/java/com/codesquad/cafe/model/UserEditRequest.java
+++ b/src/main/java/com/codesquad/cafe/model/UserEditRequest.java
@@ -1,0 +1,40 @@
+package com.codesquad.cafe.model;
+
+public class UserEditRequest {
+
+    private Long id;
+
+    private String username;
+
+    private String password;
+
+    private String confirmPassword;
+
+    private String name;
+
+    private String email;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getConfirmPassword() {
+        return confirmPassword;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/com/codesquad/cafe/model/UserJoinRequest.java
+++ b/src/main/java/com/codesquad/cafe/model/UserJoinRequest.java
@@ -1,11 +1,13 @@
 package com.codesquad.cafe.model;
 
-import jakarta.servlet.annotation.WebServlet;
-
 public class UserJoinRequest {
+
     private String username;
+
     private String password;
+
     private String name;
+
     private String email;
 
     public String getUsername() {

--- a/src/main/java/com/codesquad/cafe/servlet/IndexServlet.java
+++ b/src/main/java/com/codesquad/cafe/servlet/IndexServlet.java
@@ -33,8 +33,6 @@ public class IndexServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("IndexServlet doGet : {}", req.getRequestURL());
-
         int pageNum = getRequestedPageNum(req);
         int pageSize = getRequestedPageSize(req);
 
@@ -65,7 +63,7 @@ public class IndexServlet extends HttpServlet {
     private Page<PostDetailsDto> getPostDetailListFrom(Page<Post> posts) {
         List<PostDetailsDto> list = posts.getContent().stream()
                 .map(post -> {
-                    User user = userRepository.findById(post.getUserId()).orElseThrow(()
+                    User user = userRepository.findById(post.getAuthorId()).orElseThrow(()
                             -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
                     return new PostDetailsDto(post.getId(), post.getTitle(), post.getContent(),
                             post.getFileName(),

--- a/src/main/java/com/codesquad/cafe/servlet/PostCreateServlet.java
+++ b/src/main/java/com/codesquad/cafe/servlet/PostCreateServlet.java
@@ -1,0 +1,54 @@
+package com.codesquad.cafe.servlet;
+
+import com.codesquad.cafe.db.InMemoryPostRepository;
+import com.codesquad.cafe.db.InMemoryUserRepository;
+import com.codesquad.cafe.exception.ModelMappingException;
+import com.codesquad.cafe.model.PostCreateRequest;
+import com.codesquad.cafe.util.RequestParamModelMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PostCreateServlet extends HttpServlet {
+
+    private static final Logger log = LoggerFactory.getLogger(PostsServlet.class);
+
+    private InMemoryPostRepository postRepository;
+
+    private InMemoryUserRepository userRepository;
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        this.postRepository = (InMemoryPostRepository) getServletContext().getAttribute("postRepository");
+        this.userRepository = (InMemoryUserRepository) getServletContext().getAttribute("userRepository");
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        req.getRequestDispatcher("/WEB-INF/views/post_create_form.jsp").forward(req, resp);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            PostCreateRequest requestDto = RequestParamModelMapper.map(req.getParameterMap(),
+                    PostCreateRequest.class);
+
+            if (userRepository.findById(requestDto.getAuthorId()).isEmpty()) {
+                throw new IllegalArgumentException("user not found by id : " + requestDto.getAuthorId());
+            }
+
+            postRepository.save(requestDto.toPost());
+
+            resp.sendRedirect("/");
+        } catch (IllegalArgumentException | ModelMappingException e) {
+            resp.sendError(400);
+        }
+    }
+
+}

--- a/src/main/java/com/codesquad/cafe/servlet/PostsServlet.java
+++ b/src/main/java/com/codesquad/cafe/servlet/PostsServlet.java
@@ -1,0 +1,55 @@
+package com.codesquad.cafe.servlet;
+
+import com.codesquad.cafe.db.InMemoryPostRepository;
+import com.codesquad.cafe.db.InMemoryUserRepository;
+import com.codesquad.cafe.model.Post;
+import com.codesquad.cafe.model.PostDetailsDto;
+import com.codesquad.cafe.model.User;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PostsServlet extends HttpServlet {
+
+    private static final Logger log = LoggerFactory.getLogger(PostsServlet.class);
+
+    private InMemoryPostRepository postRepository;
+
+    private InMemoryUserRepository userRepository;
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        this.postRepository = (InMemoryPostRepository) getServletContext().getAttribute("postRepository");
+        this.userRepository = (InMemoryUserRepository) getServletContext().getAttribute("userRepository");
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            long postId = Long.parseLong(req.getPathInfo().substring(1));
+            Optional<Post> post = postRepository.findById(postId);
+            if (post.isEmpty()) {
+                resp.sendError(404);
+                return;
+            }
+            PostDetailsDto postDetail = getPostDetailsByJoin(post.get());
+            req.setAttribute("post", postDetail);
+            req.getRequestDispatcher("/WEB-INF/views/post_detail.jsp").forward(req, resp);
+        } catch (NumberFormatException e) {
+            resp.sendError(400);
+        } catch (NullPointerException e) {
+            resp.sendError(500);
+        }
+    }
+
+    private PostDetailsDto getPostDetailsByJoin(Post post) {
+        Optional<User> user = userRepository.findById(post.getAuthorId());
+        return new PostDetailsDto(post, user.get());
+    }
+}

--- a/src/main/java/com/codesquad/cafe/servlet/UserEditServlet.java
+++ b/src/main/java/com/codesquad/cafe/servlet/UserEditServlet.java
@@ -1,0 +1,89 @@
+package com.codesquad.cafe.servlet;
+
+import com.codesquad.cafe.db.UserRepository;
+import com.codesquad.cafe.exception.ModelMappingException;
+import com.codesquad.cafe.model.User;
+import com.codesquad.cafe.model.UserEditRequest;
+import com.codesquad.cafe.util.RequestParamModelMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UserEditServlet extends HttpServlet {
+
+    private static final Logger log = LoggerFactory.getLogger(UserEditServlet.class);
+
+    private static final String USER_EDIT_FORM_JSP = "/WEB-INF/views/user_edit_form.jsp";
+
+    private UserRepository userRepository;
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        this.userRepository = (UserRepository) getServletContext().getAttribute("userRepository");
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            String[] split = req.getQueryString().split("=");
+            if (split.length != 2 || !split[0].equals("id")) {
+                resp.sendError(400);
+                return;
+            }
+
+            Long id = Long.parseLong(split[1]);
+            Optional<User> user = userRepository.findById(id);
+            if (user.isEmpty() || user.get().isDeleted()) {
+                resp.sendError(400);
+                return;
+            }
+
+            req.setAttribute("user", user.get());
+            req.getRequestDispatcher(USER_EDIT_FORM_JSP).forward(req, resp);
+        } catch (NumberFormatException e) {
+            resp.sendError(400);
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            UserEditRequest requestDto = RequestParamModelMapper.map(req.getParameterMap(), UserEditRequest.class);
+
+            Optional<User> user = userRepository.findById(requestDto.getId());
+            if (user.isEmpty() || user.get().isDeleted()) {
+                resp.sendError(400);
+                return;
+            }
+
+            if (requestDto.getPassword() == null ||
+                    requestDto.getPassword().isBlank() ||
+                    !requestDto.getPassword().equals(requestDto.getConfirmPassword())) {
+                req.setAttribute("user", user.get());
+                req.setAttribute("error", "비밀번호가 일치하지 않습니다.");
+                req.getRequestDispatcher(USER_EDIT_FORM_JSP).forward(req, resp);
+                return;
+            }
+
+            User originalUser = user.get();
+            if (!originalUser.getUsername().equals(requestDto.getUsername())) {
+                req.setAttribute("user", user.get());
+                req.setAttribute("error", "유저 이름은 변경할 수 없습니다.");
+                req.getRequestDispatcher(USER_EDIT_FORM_JSP).forward(req, resp);
+                return;
+            }
+            originalUser.update(requestDto.getPassword(), requestDto.getName(), requestDto.getEmail());
+            userRepository.save(originalUser);
+            resp.sendRedirect("/users/" + user.get().getId());
+        } catch (ModelMappingException | IllegalArgumentException e) {
+            resp.sendError(400);
+        }
+
+    }
+}

--- a/src/main/java/com/codesquad/cafe/servlet/UserJoinServlet.java
+++ b/src/main/java/com/codesquad/cafe/servlet/UserJoinServlet.java
@@ -15,6 +15,8 @@ public class UserJoinServlet extends HttpServlet {
 
     private static final Logger log = LoggerFactory.getLogger(UserJoinServlet.class);
 
+    private static final String USER_JOIN_FORM_JSP = "/WEB-INF/views/user_join_form.jsp";
+
     private UserRepository userRepository;
 
     @Override
@@ -25,7 +27,7 @@ public class UserJoinServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        req.getRequestDispatcher("/WEB-INF/views/user_join_form.jsp").forward(req, resp);
+        req.getRequestDispatcher(USER_JOIN_FORM_JSP).forward(req, resp);
     }
 
     @Override
@@ -36,7 +38,7 @@ public class UserJoinServlet extends HttpServlet {
 
         if (userRepository.findByUsername(user.getUsername()).isPresent()) {
             req.setAttribute("error", "중복된 이메일입니다.");
-            req.getRequestDispatcher("/WEB-INF/views/user_join_form.jsp").forward(req, resp);
+            req.getRequestDispatcher(USER_JOIN_FORM_JSP).forward(req, resp);
             return;
         }
 

--- a/src/main/java/com/codesquad/cafe/servlet/UserLoginServlet.java
+++ b/src/main/java/com/codesquad/cafe/servlet/UserLoginServlet.java
@@ -1,0 +1,34 @@
+package com.codesquad.cafe.servlet;
+
+import com.codesquad.cafe.db.InMemoryUserRepository;
+import jakarta.servlet.ServletException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UserLoginServlet extends UserServlet {
+
+    private static final Logger log = LoggerFactory.getLogger(UserLoginServlet.class);
+
+    private InMemoryUserRepository userRepository;
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        this.userRepository = (InMemoryUserRepository) getServletContext().getAttribute("userRepository");
+    }
+
+//    @Override
+//    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+//        String username = req.getParameter("username");
+//        String password = req.getParameter("password");
+//        req.login(username, password);
+//        if(!req.authenticate(resp)){
+//            resp.sendError(401);
+//            return;
+//        }
+//        resp.setHeader("Set-Cookie", req.getSession(false).getId());
+//        resp.p
+//        resp.sendRedirect("/");
+//        super.doPost(req, resp);
+//    }
+}

--- a/src/main/java/com/codesquad/cafe/servlet/UserServlet.java
+++ b/src/main/java/com/codesquad/cafe/servlet/UserServlet.java
@@ -1,12 +1,13 @@
 package com.codesquad.cafe.servlet;
 
-import com.codesquad.cafe.db.InMemoryUserRepository;
+import com.codesquad.cafe.db.UserRepository;
 import com.codesquad.cafe.model.User;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Locale;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,24 +16,61 @@ public class UserServlet extends HttpServlet {
 
     private static final Logger log = LoggerFactory.getLogger(UserServlet.class);
 
-    private InMemoryUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Override
     public void init() throws ServletException {
         super.init();
-        this.userRepository = (InMemoryUserRepository) getServletContext().getAttribute("userRepository");
+        this.userRepository = (UserRepository) getServletContext().getAttribute("userRepository");
     }
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        Long id = Long.parseLong(req.getPathInfo().substring(1));
-        log.warn("pathInfo: {}", id);
-        Optional<User> user = userRepository.findById(id);
-        if (user.isEmpty()) {
+        try {
+            Long id = parsePathVariable(req.getPathInfo());
+            Optional<User> user = userRepository.findById(id);
+            if (user.isEmpty()) {
+                resp.sendError(404);
+                return;
+            }
+            req.setAttribute("user", user.get());
+
+            req.getRequestDispatcher("/WEB-INF/views/user_profile.jsp").forward(req, resp);
+        } catch (NumberFormatException e) {
             resp.sendError(404);
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String method = req.getParameter("_method");
+        if (method != null && method.toLowerCase(Locale.ROOT).equals("delete")) {
+            doDelete(req, resp);
             return;
         }
-        req.setAttribute("user", user.get());
-        req.getRequestDispatcher("/WEB-INF/views/user_profile.jsp").forward(req, resp);
+        resp.sendError(405);
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            Long id = Long.valueOf(req.getParameter("id"));
+            Optional<User> user = userRepository.findById(id);
+            if (user.isEmpty() ||user.get().isDeleted()){
+                resp.sendError(400);
+            }
+            User originalUser = user.get();
+            originalUser.delete();
+            userRepository.save(originalUser);
+            resp.sendRedirect("/users");
+        } catch (NumberFormatException e) {
+            resp.sendError(404);
+        }
+    }
+
+    private Long parsePathVariable(String pathInfo) {
+
+        String[] paths = pathInfo.substring(1).split("/");
+        return Long.parseLong(paths[0]);
     }
 }

--- a/src/main/java/com/codesquad/cafe/servlet/UsersServlet.java
+++ b/src/main/java/com/codesquad/cafe/servlet/UsersServlet.java
@@ -1,6 +1,6 @@
 package com.codesquad.cafe.servlet;
 
-import com.codesquad.cafe.db.InMemoryUserRepository;
+import com.codesquad.cafe.db.UserRepository;
 import com.codesquad.cafe.model.User;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
@@ -15,12 +15,12 @@ public class UsersServlet extends HttpServlet {
 
     private static final Logger log = LoggerFactory.getLogger(UsersServlet.class);
 
-    private InMemoryUserRepository userRepository;
+    private UserRepository userRepository;
 
     @Override
     public void init() throws ServletException {
         super.init();
-        this.userRepository = (InMemoryUserRepository) getServletContext().getAttribute("userRepository");
+        this.userRepository = (UserRepository) getServletContext().getAttribute("userRepository");
     }
 
     @Override

--- a/src/main/webapp/WEB-INF/views/index.jsp
+++ b/src/main/webapp/WEB-INF/views/index.jsp
@@ -46,7 +46,7 @@
                     </ul>
                 </div>
                 <div class="col-md-3 qna-write">
-                    <a href="/posts/form" class="btn btn-primary pull-right" role="button">글쓰기</a>
+                    <a href="/posts" class="btn btn-primary pull-right" role="button">글쓰기</a>
                 </div>
             </div>
         </div>

--- a/src/main/webapp/WEB-INF/views/post_create_form.jsp
+++ b/src/main/webapp/WEB-INF/views/post_create_form.jsp
@@ -1,0 +1,28 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ include file="/WEB-INF/views/include/header.jsp" %>
+
+<div class="container" id="main">
+    <div class="col-md-12 col-sm-12 col-lg-10 col-lg-offset-1">
+        <div class="panel panel-default content-main">
+            <form name="question" method="post" action="">
+                <div class="form-group">
+                    <label for="author_id">글쓴이</label>
+                    <input class="form-author_id" id="author_id" name="authorId" placeholder="글쓴이"/>
+                </div>
+                <div class="form-group">
+                    <label for="title">제목</label>
+                    <input type="text" class="form-control" id="title" name="title" placeholder="제목" required/>
+                </div>
+                <div class="form-group">
+                    <label for="content">내용</label>
+                    <textarea name="content" id="content" rows="5" class="form-control" required></textarea>
+                </div>
+                <button type="submit" class="btn btn-success clearfix pull-right">질문하기</button>
+                <div class="clearfix"/>
+            </form>
+        </div>
+    </div>
+</div>
+</div>
+<%@ include file="/WEB-INF/views/include/footer.jsp" %>

--- a/src/main/webapp/WEB-INF/views/post_detail.jsp
+++ b/src/main/webapp/WEB-INF/views/post_detail.jsp
@@ -1,0 +1,129 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" %>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ include file="/WEB-INF/views/include/header.jsp" %>
+
+<div class="container" id="main">
+    <div class="col-md-12 col-sm-12 col-lg-12">
+        <div class="panel panel-default">
+            <header class="qna-header">
+                <h2 class="qna-title">${post.title}</h2>
+            </header>
+            <div class="content-main">
+                <article class="article">
+                    <div class="article-header">
+                        <div class="article-header-thumb">
+                            <img src="https://graph.facebook.com/v2.3/100000059371774/picture"
+                                 class="article-author-thumb" alt="">
+                        </div>
+                        <div class="article-header-text">
+                            <a href="/users/${post.authorId}" class="article-author-name">${post.authorUsername}</a>
+                            <a href="/posts/${post.postId}" class="article-header-time" title="퍼머링크">
+                                <i class="icon-link"></i>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="article-doc">
+                        ${post.content}
+                    </div>
+                    <div class="article-util">
+                        <ul class="article-util-list">
+                            <li>
+                                <a class="link-modify-article" href="/posts/${post.postId}">수정</a>
+                            </li>
+                            <li>
+                                <form class="form-delete" action="/posts/${post.postId}" method="POST">
+                                    <input type="hidden" name="_method" value="DELETE">
+                                    <button class="link-delete-article" type="submit">삭제</button>
+                                </form>
+                            </li>
+                            <li>
+                                <a class="link-modify-article" href="/">목록</a>
+                            </li>
+                        </ul>
+                    </div>
+                </article>
+
+                <div class="qna-comment">
+                    <div class="qna-comment-slipp">
+                        <p class="qna-comment-count"><strong>2</strong>개의 의견</p>
+                        <div class="qna-comment-slipp-articles">
+
+                            <article class="article" id="answer-1405">
+                                <div class="article-header">
+                                    <div class="article-header-thumb">
+                                        <img src="https://graph.facebook.com/v2.3/1324855987/picture"
+                                             class="article-author-thumb" alt="">
+                                    </div>
+                                    <div class="article-header-text">
+                                        <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
+                                        <a href="#answer-1434" class="article-header-time" title="퍼머링크">
+                                            2016-01-12 14:06
+                                        </a>
+                                    </div>
+                                </div>
+                                <div class="article-doc comment-doc">
+                                    <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
+                                </div>
+                                <div class="article-util">
+                                    <ul class="article-util-list">
+                                        <li>
+                                            <a class="link-modify-article"
+                                               href="/questions/413/answers/1405/form">수정</a>
+                                        </li>
+                                        <li>
+                                            <form class="delete-answer-form" action="/questions/413/answers/1405"
+                                                  method="POST">
+                                                <input type="hidden" name="_method" value="DELETE">
+                                                <button type="submit" class="delete-answer-button">삭제</button>
+                                            </form>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </article>
+                            <article class="article" id="answer-1406">
+                                <div class="article-header">
+                                    <div class="article-header-thumb">
+                                        <img src="https://graph.facebook.com/v2.3/1324855987/picture"
+                                             class="article-author-thumb" alt="">
+                                    </div>
+                                    <div class="article-header-text">
+                                        <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
+                                        <a href="#answer-1434" class="article-header-time" title="퍼머링크">
+                                            2016-01-12 14:06
+                                        </a>
+                                    </div>
+                                </div>
+                                <div class="article-doc comment-doc">
+                                    <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
+                                </div>
+                                <div class="article-util">
+                                    <ul class="article-util-list">
+                                        <li>
+                                            <a class="link-modify-article"
+                                               href="/questions/413/answers/1405/form">수정</a>
+                                        </li>
+                                        <li>
+                                            <form class="form-delete" action="/questions/413/answers/1405"
+                                                  method="POST">
+                                                <input type="hidden" name="_method" value="DELETE">
+                                                <button type="submit" class="delete-answer-button">삭제</button>
+                                            </form>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </article>
+                            <form class="submit-write">
+                                <div class="form-group" style="padding:14px;">
+                                    <textarea class="form-control" placeholder="Update your status"></textarea>
+                                </div>
+                                <button class="btn btn-success pull-right" type="button">답변하기</button>
+                                <div class="clearfix"/>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<%@ include file="/WEB-INF/views/include/footer.jsp" %>

--- a/src/main/webapp/WEB-INF/views/user_edit_form.jsp
+++ b/src/main/webapp/WEB-INF/views/user_edit_form.jsp
@@ -1,0 +1,45 @@
+<%--<%@ page language="java" contentType="text/html; charset=UTF-8" %>--%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+<%@ include file="/WEB-INF/views/include/header.jsp" %>
+
+<div class="container" id="main">
+    <div class="col-md-6 col-md-offset-3">
+        <div class="panel panel-default content-main">
+            <c:if test="${not empty error}">
+                <script type="text/javascript">
+                    alert("${error}");
+                </script>
+            </c:if>
+            <form name="userModify" method="post" action="/users/edit">
+                <input type="hidden" name="userId" value="${user.id}">
+                <input type="hidden" name="username" value="${user.username}">
+                <div class="form-group">
+                    <label for="userId">사용자 아이디</label>
+                    <input type="text" class="form-control" id="userId" name="username" placeholder="User ID"
+                           value="${user.username}" readonly>
+                </div>
+                <div class="form-group">
+                    <label for="password">비밀번호</label>
+                    <input type="password" class="form-control" id="password" name="password" placeholder="Password">
+                </div>
+                <div class="form-group">
+                    <label for="confirmPassword">비밀번호 확인</label>
+                    <input type="password" class="form-control" id="confirmPassword" name="confirmPassword"
+                           placeholder="Confirm Password">
+                </div>
+                <div class="form-group">
+                    <label for="name">이름</label>
+                    <input class="form-control" id="name" name="name" placeholder="Name" value="${user.name}">
+                </div>
+                <div class="form-group">
+                    <label for="email">이메일</label>
+                    <input type="email" class="form-control" id="email" name="email" placeholder="Email"
+                           value="${user.email}">
+                </div>
+                <button type="submit" class="btn btn-success clearfix pull-right">수정하기</button>
+                <div class="clearfix"/>
+            </form>
+        </div>
+    </div>
+</div>
+<%@ include file="/WEB-INF/views/include/footer.jsp" %>

--- a/src/main/webapp/WEB-INF/views/user_profile.jsp
+++ b/src/main/webapp/WEB-INF/views/user_profile.jsp
@@ -18,6 +18,19 @@
                                 <a href="#" class="btn btn-xs btn-default"><span
                                         class="glyphicon glyphicon-envelope"></span>&nbsp;${user.email}</a>
                             </p>
+                            <c:choose>
+                                <c:when test="${user.deleted}">
+                                    <h4 class="media-heading">탈퇴한 유저입니다.</h4>
+                                </c:when>
+                                <c:when test="${not user.deleted}">
+                                    <a class="link-modify-article" href="/users/edit?id=${user.id}">수정</a>
+                                    <form class="form-delete" action="/users/${user.id}" method="POST">
+                                        <input type="hidden" name="_method" value="DELETE">
+                                        <input type="hidden" name="id" value="${user.id}">
+                                        <button class="link-delete-article" type="submit">탈퇴</button>
+                                    </form>
+                                </c:when>
+                            </c:choose>
                         </div>
                     </div>
                 </div>

--- a/src/main/webapp/WEB-INF/views/users.jsp
+++ b/src/main/webapp/WEB-INF/views/users.jsp
@@ -17,6 +17,11 @@
                                 <strong class="subject">
                                     <a href="/users/${user.id}">${user.username}</a>
                                 </strong>
+                                <c:if test="${user.deleted}">
+                                    <strong class="subject" style="color:red">
+                                        탈퇴한 사용자
+                                    </strong>
+                                </c:if>
                                 <div class="auth-info">
                                     <i class="icon-add-comment"></i>
                                     <span class="time">${user.createdAt}</span>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -24,6 +24,15 @@
     </servlet-mapping>
 
     <servlet>
+        <servlet-name>user_edit</servlet-name>
+        <servlet-class>com.codesquad.cafe.servlet.UserEditServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>user_edit</servlet-name>
+        <url-pattern>/users/edit/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <servlet-name>user</servlet-name>
         <servlet-class>com.codesquad.cafe.servlet.UserServlet</servlet-class>
     </servlet>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -5,19 +5,6 @@
                       https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
          version="6.0">
 
-
-    <servlet-mapping>
-        <servlet-name>default</servlet-name>
-        <url-pattern>/static/*</url-pattern>
-    </servlet-mapping>
-    <servlet>
-        <servlet-name>index</servlet-name>
-        <servlet-class>com.codesquad.cafe.servlet.IndexServlet</servlet-class>
-    </servlet>
-    <servlet-mapping>
-        <servlet-name>index</servlet-name>
-        <url-pattern>/</url-pattern>
-    </servlet-mapping>
     <servlet>
         <servlet-name>user_join</servlet-name>
         <servlet-class>com.codesquad.cafe.servlet.UserJoinServlet</servlet-class>
@@ -26,6 +13,7 @@
         <servlet-name>user_join</servlet-name>
         <url-pattern>/users/join</url-pattern>
     </servlet-mapping>
+
     <servlet>
         <servlet-name>users</servlet-name>
         <servlet-class>com.codesquad.cafe.servlet.UsersServlet</servlet-class>
@@ -34,6 +22,7 @@
         <servlet-name>users</servlet-name>
         <url-pattern>/users</url-pattern>
     </servlet-mapping>
+
     <servlet>
         <servlet-name>user</servlet-name>
         <servlet-class>com.codesquad.cafe.servlet.UserServlet</servlet-class>
@@ -41,6 +30,38 @@
     <servlet-mapping>
         <servlet-name>user</servlet-name>
         <url-pattern>/users/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>post_detail</servlet-name>
+        <servlet-class>com.codesquad.cafe.servlet.PostsServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>post_detail</servlet-name>
+        <url-pattern>/posts/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>post_create</servlet-name>
+        <servlet-class>com.codesquad.cafe.servlet.PostCreateServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>post_create</servlet-name>
+        <url-pattern>/posts</url-pattern>
+    </servlet-mapping>
+
+    <servlet-mapping>
+        <servlet-name>default</servlet-name>
+        <url-pattern>/static/*</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>index</servlet-name>
+        <servlet-class>com.codesquad.cafe.servlet.IndexServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>index</servlet-name>
+        <url-pattern>/</url-pattern>
     </servlet-mapping>
 
     <!--  에러 페이지 설정 -->

--- a/src/test/java/com/codesquad/cafe/servlet/IndexServletTest.java
+++ b/src/test/java/com/codesquad/cafe/servlet/IndexServletTest.java
@@ -1,5 +1,6 @@
 package com.codesquad.cafe.servlet;
 
+import static com.codesquad.cafe.TestUtil.assertErrorPageResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -15,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.http.HttpResponse;
-import org.apache.http.util.EntityUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -43,10 +43,10 @@ class IndexServletTest extends E2ETestBase {
         postRepository = (PostRepository) context.getServletContext().getAttribute("postRepository");
         posts = new ArrayList<>();
         user = userRepository.save(User.of("woowa", "1234", "김수현", "woowa@gmail.com"));
-        posts.add(postRepository.save(new Post(user.getId(), "title1", "content1", null)));
-        posts.add(postRepository.save(new Post(user.getId(), "title2", "content2", null)));
-        posts.add(postRepository.save(new Post(user.getId(), "title3", "content3", null)));
-        posts.add(postRepository.save(new Post(user.getId(), "title4", "content4", null)));
+        posts.add(postRepository.save(Post.of(user.getId(), "title1", "content1", null)));
+        posts.add(postRepository.save(Post.of(user.getId(), "title2", "content2", null)));
+        posts.add(postRepository.save(Post.of(user.getId(), "title3", "content3", null)));
+        posts.add(postRepository.save(Post.of(user.getId(), "title4", "content4", null)));
     }
 
     @AfterAll
@@ -121,8 +121,6 @@ class IndexServletTest extends E2ETestBase {
         HttpResponse response = post(path, "");
 
         //then
-        assertEquals(405, response.getStatusLine().getStatusCode());
-        assertTrue(EntityUtils.toString(response.getEntity()).contains("405 Method Not Allowed"));
+        assertErrorPageResponse(response, 405);
     }
-
 }

--- a/src/test/java/com/codesquad/cafe/servlet/PostCreateServletTest.java
+++ b/src/test/java/com/codesquad/cafe/servlet/PostCreateServletTest.java
@@ -1,0 +1,122 @@
+package com.codesquad.cafe.servlet;
+
+import static com.codesquad.cafe.TestUtil.assertErrorPageResponse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.codesquad.cafe.E2ETestBase;
+import com.codesquad.cafe.SavedHttpResponse;
+import com.codesquad.cafe.db.PostRepository;
+import com.codesquad.cafe.db.UserRepository;
+import com.codesquad.cafe.model.User;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import org.apache.http.HttpResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostCreateServletTest extends E2ETestBase {
+
+    private static PostRepository postRepository;
+
+    private static UserRepository userRepository;
+
+    private static User user;
+
+    private final String path = "/posts";
+
+
+    @BeforeAll
+    static void beforeAll() {
+        postRepository = (PostRepository) context.getServletContext().getAttribute("postRepository");
+        userRepository = (UserRepository) context.getServletContext().getAttribute("userRepository");
+        user = userRepository.save(User.of("javajigi", "1234", "박재성", "test@gmail.com"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        postRepository.deleteAll();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        userRepository.deleteAll();
+    }
+
+
+    @Test
+    @DisplayName("글쓰기 페이지를 반환한다.")
+    void testDoGetPostCreateForm() throws IOException {
+        //when
+        SavedHttpResponse response = get(path);
+        String html = response.getBody();
+
+        //then
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertEquals("text/html;charset=UTF-8", response.getContentType());
+        assertTrue(html.contains("authorId"));
+        assertTrue(html.contains("title"));
+        assertTrue(html.contains("content"));
+    }
+
+    @Test
+    @DisplayName("글쓰기에 성공하면 홈으로로 리다이렉트한다.")
+    void testDoPostCreateUser() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(path,
+                "authorId=" + user.getId() + "&title=title&content=content");
+
+        //then
+        assertEquals(302, response.getStatusLine().getStatusCode());
+        assertEquals("/", response.getFirstHeader("Location").getValue());
+    }
+
+    @Test
+    @DisplayName("없는 userId로 요청하면 400 응답한다.")
+    void testDoPostFailUnknownUserId() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(path,
+                "authorId=" + 1000 + "&title=title&content=content");
+
+        //then
+        assertErrorPageResponse(response, 400);
+    }
+
+    @Test
+    @DisplayName("userId로 숫자가 아닌 값을 요청하면 400 응답한다.")
+    void testDoPostFailStringUserId() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(path,
+                "authorId=author&title=title&content=content");
+
+        //then
+        assertErrorPageResponse(response, 400);
+    }
+
+    @Test
+    @DisplayName("누락된 필드로 요청하면 400 응답한다.")
+    void testDoPostFailAbsentField() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(path,
+                "authorId=" + user.getId() + "&content=content");
+
+        //then
+        assertErrorPageResponse(response, 400);
+    }
+
+    @Test
+    @DisplayName("빈 필드로 요청하면 400 응답한다.")
+    void testDoPostFailEmptyField() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(path,
+                "authorId=" + user.getId() + "&title=&content=content");
+
+        //then
+        assertErrorPageResponse(response, 400);
+    }
+
+
+}

--- a/src/test/java/com/codesquad/cafe/servlet/PostsServletTest.java
+++ b/src/test/java/com/codesquad/cafe/servlet/PostsServletTest.java
@@ -1,0 +1,90 @@
+package com.codesquad.cafe.servlet;
+
+import static com.codesquad.cafe.TestUtil.assertErrorPageResponse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.codesquad.cafe.E2ETestBase;
+import com.codesquad.cafe.SavedHttpResponse;
+import com.codesquad.cafe.db.PostRepository;
+import com.codesquad.cafe.db.UserRepository;
+import com.codesquad.cafe.model.Post;
+import com.codesquad.cafe.model.User;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import org.apache.http.HttpResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostServletTest extends E2ETestBase {
+
+    private static PostRepository postRepository;
+
+    private static UserRepository userRepository;
+
+    private static User user;
+
+    private static Post post;
+
+    private final String path = "/posts/";
+
+
+    @BeforeAll
+    static void beforeAll() {
+        postRepository = (PostRepository) context.getServletContext().getAttribute("postRepository");
+        userRepository = (UserRepository) context.getServletContext().getAttribute("userRepository");
+        user = userRepository.save(User.of("javajigi", "1234", "박재성", "test@gmail.com"));
+        post = postRepository.save(Post.of(user.getId(), "title1", "content1", null));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        userRepository.deleteAll();
+        postRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("게시판 상세보기 페이지를 반환한다.")
+    void testDoGetUserProfile() throws IOException, URISyntaxException {
+        //when
+        SavedHttpResponse response = get(getPath(post.getId()));
+        String html = response.getBody();
+
+        //then
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertEquals("text/html;charset=UTF-8", response.getContentType());
+        assertTrue(html.contains(post.getTitle()));
+        assertTrue(html.contains(user.getUsername()));
+        assertTrue(html.contains("/users/" + user.getId()));
+        assertTrue(html.contains("/posts/" + post.getId()));
+        assertTrue(html.contains(post.getContent()));
+        assertTrue(html.contains("수정"));
+        assertTrue(html.contains("삭제"));
+    }
+
+    @Test
+    @DisplayName("없는 포스트 조회 요청시 404 응답을 반환한다.")
+    void testDoGetPostCreateForm() throws IOException {
+        //when
+        SavedHttpResponse response = get(getPath(1000));
+
+        //then
+        assertErrorPageResponse(response, 404);
+    }
+
+    @Test
+    @DisplayName("POST 요청시 405 응답을 반환한다.")
+    void testDoPostReturn405() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(getPath(1), "");
+
+        //then
+        assertErrorPageResponse(response, 405);
+    }
+
+    private String getPath(long id) {
+        return path + id;
+    }
+}

--- a/src/test/java/com/codesquad/cafe/servlet/UserEditServletTest.java
+++ b/src/test/java/com/codesquad/cafe/servlet/UserEditServletTest.java
@@ -1,0 +1,206 @@
+package com.codesquad.cafe.servlet;
+
+import static com.codesquad.cafe.TestUtil.assertErrorPageResponse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.codesquad.cafe.E2ETestBase;
+import com.codesquad.cafe.SavedHttpResponse;
+import com.codesquad.cafe.db.UserRepository;
+import com.codesquad.cafe.model.User;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserEditServletTest extends E2ETestBase {
+
+    private static String path = "/users/edit";
+
+    private static UserRepository userRepository;
+
+    private User user;
+
+    @BeforeAll
+    static void beforeAll() {
+        userRepository = (UserRepository) context.getServletContext().getAttribute("userRepository");
+    }
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(User.of("woowa", "1234", "박재성", "woowa@gmail.com"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("유저 수정 페이지를 반환한다.")
+    void testDoGetUserProfile() throws IOException, URISyntaxException {
+        //when
+        SavedHttpResponse response = get(getPath(user.getId()));
+        String html = response.getBody();
+
+        //then
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertEquals("text/html;charset=UTF-8", response.getContentType());
+        assertTrue(html.contains("userModify"));
+        assertTrue(html.contains(user.getUsername()));
+        assertTrue(html.contains(user.getEmail()));
+    }
+
+    @Test
+    @DisplayName("없는 유저의 수정 페이지를 요처하면404 페이지를 응답한다.")
+    void testDoGetUnknownUser() throws IOException, URISyntaxException {
+        //when
+        SavedHttpResponse response = get(getPath(100000L));
+
+        //then
+        assertErrorPageResponse(response, 400);
+    }
+
+    @Test
+    @DisplayName("탈퇴한 유저의 유저의 수정 페이지를 요처하면404 페이지를 응답한다.")
+    void testDoGetDeletedUser() throws IOException, URISyntaxException {
+        //given
+        deleteUser(user);
+        //when
+        SavedHttpResponse response = get(getPath(100000L));
+
+        //then
+        assertErrorPageResponse(response, 400);
+    }
+
+    @Test
+    @DisplayName("유저 수정에 성공하면 유저 리스트로 리다이렉트한다.")
+    void testDoPostEditUser() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(path,
+                getBody(user.getId(), user.getUsername(), "1234", "1234", "woo@gmail.com", "박재성"));
+
+        //then
+        assertEquals(302, response.getStatusLine().getStatusCode());
+        assertEquals("/users/" + user.getId(), response.getFirstHeader("Location").getValue());
+        User updatedUser = userRepository.findById(user.getId()).get();
+        assertEquals("woo@gmail.com", updatedUser.getEmail());
+        assertEquals("1234", updatedUser.getPassword());
+    }
+
+    @Test
+    @DisplayName("유저 수정에 실패한다 - 비밀번호 불일치")
+    void testDoPostEditUserFailPassword() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(path,
+                getBody(user.getId(), user.getUsername(), "1234", "1111", "woo@gmail.com", "박재성"));
+
+        //then
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertEquals("text/html;charset=UTF-8", response.getEntity().getContentType().getValue());
+        String html = EntityUtils.toString(response.getEntity());
+        assertTrue(html.contains("userModify"));
+        assertTrue(html.contains(user.getUsername()));
+        assertTrue(html.contains("비밀번호가 일치하지 않습니다."));
+        assertTrue(html.contains(user.getEmail()));
+    }
+
+    @Test
+    @DisplayName("유저 수정에 실패한다 - 필드 누락")
+    void testDoPostEditUserFailFieldAbsent() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(path,
+                "id=" + user.getId() + "&username=" + user.getUsername() + "&password=1234" + "&confirmPassword=1234");
+
+        //then
+        assertErrorPageResponse(response, 400);
+    }
+
+    @Test
+    @DisplayName("유저 수정에 실패한다 - 빈 필드")
+    void testDoPostEditUserFailFieldEmpty() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(path,
+                getBody(user.getId(), user.getUsername(), "1234", "1234", "", "박재성"));
+
+        //then
+        assertErrorPageResponse(response, 400);
+    }
+
+    @Test
+    @DisplayName("유저 수정에 실패한다 - 빈 비밀번호")
+    void testDoPostEditUserFailPasswordEmpty() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(path,
+                getBody(user.getId(), user.getUsername(), "", "", "woo@gmail.com", "박재성"));
+
+        //then
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertEquals("text/html;charset=UTF-8", response.getEntity().getContentType().getValue());
+        String html = EntityUtils.toString(response.getEntity());
+        assertTrue(html.contains("userModify"));
+        assertTrue(html.contains(user.getUsername()));
+        assertTrue(html.contains("비밀번호가 일치하지 않습니다."));
+        assertTrue(html.contains(user.getEmail()));
+    }
+
+    @Test
+    @DisplayName("유저 이름은 수정할 수 없다.")
+    void testDoPostEditUserFailEditUsername() throws IOException, URISyntaxException {
+        //when
+        HttpResponse response = post(path,
+                getBody(user.getId(), "nweUsername", "1234", "1234", "woo@gmail.com", "박재성"));
+
+        //then
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        assertEquals("text/html;charset=UTF-8", response.getEntity().getContentType().getValue());
+        String html = EntityUtils.toString(response.getEntity());
+        assertTrue(html.contains("userModify"));
+        assertTrue(html.contains(user.getUsername()));
+        assertTrue(html.contains("유저 이름은 변경할 수 없습니다."));
+        assertTrue(html.contains(user.getEmail()));
+    }
+
+    @Test
+    @DisplayName("유저 수정에 실패한다 - 탈퇴한 유저")
+    void testDoPostEditUserFailDeletedUser() throws IOException, URISyntaxException {
+        //given
+        deleteUser(user);
+        //when
+        HttpResponse response = post(path,
+                getBody(user.getId(), user.getUsername(), "1234", "1234", "woo@gmail.com", "박재성"));
+
+        //then
+        assertErrorPageResponse(response, 400);
+    }
+
+    public void deleteUser(User user) {
+        user.delete();
+        userRepository.save(user);
+    }
+
+    public String getPath(Long id) {
+        return path + "?id=" + id;
+    }
+
+    public String getBody(Long id, String username, String password, String confirmPassword, String email, String name)
+            throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb
+                .append("id=").append(id)
+                .append("&username=").append(username)
+                .append("&password=").append(password)
+                .append("&confirmPassword=").append(confirmPassword)
+                .append("&name=").append(name)
+                .append("&email=").append(URLEncoder.encode(email, "UTF-8"));
+        return sb.toString();
+    }
+
+
+}

--- a/src/test/java/com/codesquad/cafe/servlet/UserServletTest.java
+++ b/src/test/java/com/codesquad/cafe/servlet/UserServletTest.java
@@ -29,7 +29,7 @@ class UserServletTest extends E2ETestBase {
 
     @BeforeEach
     void setUp() {
-        user = userRepository.save(User.of("woowa", "1234", "김수현", "woowa@gmail.com"));
+        user = userRepository.save(User.of("woowa", "1234", "박재성", "woowa@gmail.com"));
     }
 
     @AfterEach


### PR DESCRIPTION
## 구현 내용
## 1. 유저 정보 수정
### 1-1. 유저 수정 폼 요청 
+ 현재 로그인 기능 없으므로 유저 수정 폼 요청시 쿼리파라미터로 유저 id 전달하기 ex) GET /users/edit?id=1
+ 탈퇴하거나 없는 유저는 수정할 수 없다-> 404 응답
+ 추후 쿠키에서 로그인 상태 확인 및 세션에 저장된 id 사용할 예정
### 1-2.유저 수정
+ 탈퇴하거나 없는 유저는 수정할 수 없다-> 404 응답
+ Username은 수정할 수 없다 
  + Html에서 username, id 숨김
  + Username 다르게 전달시 폼으로 다시 전달 및 오류 alert 표시
+ 빈 문자열로 수정할 수 없다 -> 400
+ email, password, name은 Password는 confirmPassword와 일치해야한다 가입 폼 다시 전달  및 오류 alert 표시

### 1-3.유저 탈퇴
+ soft delete 구현
+ 유저 조회페이지에서 탈퇴한 유저 표시
+ 유저 프로필페이지에서 수정 탈퇴 버튼 숨김
+ 탈퇴한 유저는 수정이나 탈퇴가 불가능하다
+ post 요청으로 폼 전달라면서 _method=delete 요청 파라미터 전달

### 2. 게시글 작성
## 2-1. 게시글 작성 폼 요청
 + 현재 로그인 기능 없으므로 모두 요청 가능
### 2-2. 게시글 작성
+ 현재 로그인 기능 없으므로 폼에 직접 user id 입력 필요
+ 게시글 작성 성공시 홈으로 리다이렉트
+ 잘못된 user id 요청시 400 응답
+ title, content 빈 문자열은 입력할 수 없다 400 bad request
+ 없는 유저이거나 탈퇴한 유저의 경우 400 bad request 