### PR TITLE
[이호석] step-4 로그인 구현

### DIFF
--- a/src/main/java/com/wootecam/jspcafe/config/DataSourceManager.java
+++ b/src/main/java/com/wootecam/jspcafe/config/DataSourceManager.java
@@ -21,6 +21,11 @@ public class DataSourceManager {
             Properties props = new Properties();
             loadProperties(props);
             String driverClassName = props.getProperty("datasource.driverClassName");
+            try {
+                Class.forName(driverClassName);
+            } catch (ClassNotFoundException e) {
+                log.error("드라이버 클래스를 로딩할 수 없습니다.");
+            }
             String url = props.getProperty("datasource.url");
             String user = props.getProperty("datasource.user");
             String password = props.getProperty("datasource.password");

--- a/src/main/java/com/wootecam/jspcafe/domain/Question.java
+++ b/src/main/java/com/wootecam/jspcafe/domain/Question.java
@@ -10,25 +10,28 @@ public class Question {
     private final String title;
     private final String contents;
     private final LocalDateTime createdTime;
+    private final Long userPrimaryId;
 
-    public Question(final String writer, final String title, final String contents, final LocalDateTime createdTime) {
-        validate(writer, title, contents, createdTime);
+    public Question(final String writer, final String title, final String contents, final LocalDateTime createdTime,
+                    final Long userPrimaryId) {
+        validate(writer, title, contents, createdTime, userPrimaryId);
         this.writer = writer;
         this.title = title;
         this.contents = contents;
         this.createdTime = createdTime;
+        this.userPrimaryId = userPrimaryId;
     }
 
     public Question(final Long id, final String writer, final String title, final String contents,
-                    final LocalDateTime createdTime) {
-        this(writer, title, contents, createdTime);
+                    final LocalDateTime createdTime, final Long userPrimaryId) {
+        this(writer, title, contents, createdTime, userPrimaryId);
         this.id = id;
     }
 
     private void validate(final String writer, final String title, final String contents,
-                          final LocalDateTime createdTime) {
+                          final LocalDateTime createdTime, final Long userPrimaryId) {
         if (Objects.isNull(writer) || Objects.isNull(title) || Objects.isNull(contents) || Objects.isNull(createdTime)
-                || writer.isEmpty() || title.isEmpty() || contents.isEmpty()) {
+                || Objects.isNull(userPrimaryId) || writer.isEmpty() || title.isEmpty() || contents.isEmpty()) {
             throw new IllegalArgumentException("질문 작성 시 모든 정보를 입력해야 합니다.");
         }
     }
@@ -53,6 +56,10 @@ public class Question {
         return createdTime;
     }
 
+    public Long getUserPrimaryId() {
+        return userPrimaryId;
+    }
+
     @Override
     public String toString() {
         return "Question{" +
@@ -61,6 +68,7 @@ public class Question {
                 ", title='" + title + '\'' +
                 ", contents='" + contents + '\'' +
                 ", createdTime=" + createdTime +
+                ", userPrimaryId=" + userPrimaryId +
                 '}';
     }
 }

--- a/src/main/java/com/wootecam/jspcafe/domain/QuestionRepository.java
+++ b/src/main/java/com/wootecam/jspcafe/domain/QuestionRepository.java
@@ -7,7 +7,7 @@ public interface QuestionRepository {
 
     void save(final Question question);
 
-    List<Question> findAll();
+    List<Question> findAllOrderByCreatedTimeDesc();
 
     Optional<Question> findById(final Long id);
 }

--- a/src/main/java/com/wootecam/jspcafe/domain/UserRepository.java
+++ b/src/main/java/com/wootecam/jspcafe/domain/UserRepository.java
@@ -7,7 +7,7 @@ public interface UserRepository {
 
     void save(User user);
 
-    List<User> findAll();
+    List<User> findAllOrderByIdDesc();
 
     Optional<User> findById(final Long id);
 

--- a/src/main/java/com/wootecam/jspcafe/listener/ApplicationContextListener.java
+++ b/src/main/java/com/wootecam/jspcafe/listener/ApplicationContextListener.java
@@ -11,6 +11,7 @@ import com.wootecam.jspcafe.servlet.HomeServlet;
 import com.wootecam.jspcafe.servlet.question.QuestionDetailServlet;
 import com.wootecam.jspcafe.servlet.question.QuestionServlet;
 import com.wootecam.jspcafe.servlet.user.SignInFormServlet;
+import com.wootecam.jspcafe.servlet.user.SignOutServlet;
 import com.wootecam.jspcafe.servlet.user.SignupFormServlet;
 import com.wootecam.jspcafe.servlet.user.UserEditServlet;
 import com.wootecam.jspcafe.servlet.user.UserProfileServlet;
@@ -46,6 +47,8 @@ public class ApplicationContextListener implements ServletContextListener {
                 .addMapping("/users/edit/*");
         servletContext.addServlet("signInFormServlet", new SignInFormServlet(userService))
                 .addMapping("/users/sign-in");
+        servletContext.addServlet("signOutServlet", new SignOutServlet())
+                .addMapping("/users/sign-out");
 
         servletContext.addServlet("questionServlet", new QuestionServlet(questionService))
                 .addMapping("/questions");

--- a/src/main/java/com/wootecam/jspcafe/repository/JdbcQuestionRepository.java
+++ b/src/main/java/com/wootecam/jspcafe/repository/JdbcQuestionRepository.java
@@ -44,8 +44,8 @@ public class JdbcQuestionRepository implements QuestionRepository {
     }
 
     @Override
-    public List<Question> findAll() {
-        String query = "SELECT id, writer, title, contents, created_time, users_primary_id FROM question";
+    public List<Question> findAllOrderByCreatedTimeDesc() {
+        String query = "SELECT id, writer, title, contents, created_time, users_primary_id FROM question ORDER BY created_time DESC";
 
         return jdbcTemplate.selectAll(
                 query,

--- a/src/main/java/com/wootecam/jspcafe/repository/JdbcQuestionRepository.java
+++ b/src/main/java/com/wootecam/jspcafe/repository/JdbcQuestionRepository.java
@@ -21,13 +21,15 @@ public class JdbcQuestionRepository implements QuestionRepository {
                         + "    writer       VARCHAR(30),\n"
                         + "    title        TEXT,\n"
                         + "    contents     TEXT,\n"
-                        + "    created_time DATETIME\n"
+                        + "    created_time DATETIME,\n"
+                        + "    users_primary_id BIGINT,\n"
+                        + "    FOREIGN KEY (users_primary_id) REFERENCES users(id)\n"
                         + ")");
     }
 
     @Override
     public void save(final Question question) {
-        String query = "INSERT INTO question(writer, title, contents, created_time) VALUES (?, ?, ?, ?)";
+        String query = "INSERT INTO question(writer, title, contents, created_time, users_primary_id) VALUES (?, ?, ?, ?, ?)";
 
         jdbcTemplate.update(
                 query,
@@ -36,13 +38,14 @@ public class JdbcQuestionRepository implements QuestionRepository {
                     ps.setString(2, question.getTitle());
                     ps.setString(3, question.getContents());
                     ps.setTimestamp(4, Timestamp.valueOf(question.getCreatedTime()));
+                    ps.setLong(5, question.getUserPrimaryId());
                 }
         );
     }
 
     @Override
     public List<Question> findAll() {
-        String query = "SELECT id, writer, title, contents, created_time FROM question";
+        String query = "SELECT id, writer, title, contents, created_time, users_primary_id FROM question";
 
         return jdbcTemplate.selectAll(
                 query,
@@ -51,14 +54,15 @@ public class JdbcQuestionRepository implements QuestionRepository {
                         resultSet.getString(2),
                         resultSet.getString(3),
                         resultSet.getString(4),
-                        resultSet.getTimestamp(5).toLocalDateTime()
+                        resultSet.getTimestamp(5).toLocalDateTime(),
+                        resultSet.getLong(6)
                 )
         );
     }
 
     @Override
     public Optional<Question> findById(final Long id) {
-        String query = "SELECT id, writer, title, contents, created_time FROM question WHERE id = ?";
+        String query = "SELECT id, writer, title, contents, created_time, users_primary_id FROM question WHERE id = ?";
 
         Question question = jdbcTemplate.selectOne(
                 query,
@@ -68,7 +72,8 @@ public class JdbcQuestionRepository implements QuestionRepository {
                         resultSet.getString(2),
                         resultSet.getString(3),
                         resultSet.getString(4),
-                        resultSet.getTimestamp(5).toLocalDateTime()
+                        resultSet.getTimestamp(5).toLocalDateTime(),
+                        resultSet.getLong(6)
                 )
         );
 

--- a/src/main/java/com/wootecam/jspcafe/repository/JdbcUserRepository.java
+++ b/src/main/java/com/wootecam/jspcafe/repository/JdbcUserRepository.java
@@ -41,8 +41,8 @@ public class JdbcUserRepository implements UserRepository {
     }
 
     @Override
-    public List<User> findAll() {
-        String query = "SELECT id, user_id, password, name, email FROM users";
+    public List<User> findAllOrderByIdDesc() {
+        String query = "SELECT id, user_id, password, name, email FROM users ORDER BY id DESC";
 
         return jdbcTemplate.selectAll(
                 query,

--- a/src/main/java/com/wootecam/jspcafe/service/QuestionService.java
+++ b/src/main/java/com/wootecam/jspcafe/service/QuestionService.java
@@ -26,7 +26,7 @@ public class QuestionService {
     }
 
     public List<Question> readAll() {
-        return questionRepository.findAll();
+        return questionRepository.findAllOrderByCreatedTimeDesc();
     }
 
     public Question read(final Long id) {

--- a/src/main/java/com/wootecam/jspcafe/service/QuestionService.java
+++ b/src/main/java/com/wootecam/jspcafe/service/QuestionService.java
@@ -17,8 +17,8 @@ public class QuestionService {
         this.questionRepository = questionRepository;
     }
 
-    public void append(final String writer, final String title, final String contents) {
-        Question question = new Question(writer, title, contents, LocalDateTime.now());
+    public void append(final String writer, final String title, final String contents, final Long writerId) {
+        Question question = new Question(writer, title, contents, LocalDateTime.now(), writerId);
 
         log.info("write question = {}", question);
 

--- a/src/main/java/com/wootecam/jspcafe/service/UserService.java
+++ b/src/main/java/com/wootecam/jspcafe/service/UserService.java
@@ -59,4 +59,16 @@ public class UserService {
             throw new IllegalArgumentException("로그인 정보를 모두 입력해야 합니다.");
         }
     }
+
+    public User readSignInUser(final Long editId, final User signInUser) {
+        if (Objects.isNull(editId) || Objects.isNull(signInUser)) {
+            throw new IllegalArgumentException("프로필 수정을 할 사용자를 찾을 수 없습니다.");
+        }
+
+        if (!editId.equals(signInUser.getId())) {
+            throw new IllegalArgumentException("자신의 프로필만 수정할 수 있습니다.");
+        }
+
+        return read(editId);
+    }
 }

--- a/src/main/java/com/wootecam/jspcafe/service/UserService.java
+++ b/src/main/java/com/wootecam/jspcafe/service/UserService.java
@@ -27,7 +27,7 @@ public class UserService {
     }
 
     public List<User> readAll() {
-        return userRepository.findAll();
+        return userRepository.findAllOrderByIdDesc();
     }
 
     public User read(final Long id) {

--- a/src/main/java/com/wootecam/jspcafe/servlet/question/QuestionServlet.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/question/QuestionServlet.java
@@ -27,8 +27,7 @@ public class QuestionServlet extends HttpServlet {
         User signInUser = (User) req.getSession().getAttribute("signInUser");
 
         if (Objects.isNull(signInUser)) {
-            req.getRequestDispatcher("/WEB-INF/views/user/login.jsp")
-                    .forward(req, resp);
+            resp.sendRedirect("/users/sign-in");
             return;
         }
 
@@ -43,8 +42,7 @@ public class QuestionServlet extends HttpServlet {
         User signInUser = (User) req.getSession().getAttribute("signInUser");
 
         if (Objects.isNull(signInUser)) {
-            req.getRequestDispatcher("/WEB-INF/user/login.jsp")
-                    .forward(req, resp);
+            resp.sendRedirect("/users/sign-in");
             return;
         }
 

--- a/src/main/java/com/wootecam/jspcafe/servlet/question/QuestionServlet.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/question/QuestionServlet.java
@@ -1,11 +1,13 @@
 package com.wootecam.jspcafe.servlet.question;
 
+import com.wootecam.jspcafe.domain.User;
 import com.wootecam.jspcafe.service.QuestionService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,8 +24,15 @@ public class QuestionServlet extends HttpServlet {
     @Override
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
             throws ServletException, IOException {
-        log.debug("forward to question form");
+        User signInUser = (User) req.getSession().getAttribute("signInUser");
 
+        if (Objects.isNull(signInUser)) {
+            req.getRequestDispatcher("/WEB-INF/views/user/login.jsp")
+                    .forward(req, resp);
+            return;
+        }
+
+        log.debug("forward to question form");
         req.getRequestDispatcher("/WEB-INF/views/qna/form.jsp")
                 .forward(req, resp);
     }
@@ -31,10 +40,19 @@ public class QuestionServlet extends HttpServlet {
     @Override
     protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
             throws ServletException, IOException {
+        User signInUser = (User) req.getSession().getAttribute("signInUser");
+
+        if (Objects.isNull(signInUser)) {
+            req.getRequestDispatcher("/WEB-INF/user/login.jsp")
+                    .forward(req, resp);
+            return;
+        }
+
         questionService.append(
                 req.getParameter("writer"),
                 req.getParameter("title"),
-                req.getParameter("contents")
+                req.getParameter("contents"),
+                signInUser.getId()
         );
 
         resp.sendRedirect("/");

--- a/src/main/java/com/wootecam/jspcafe/servlet/user/SignOutServlet.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/user/SignOutServlet.java
@@ -1,0 +1,18 @@
+package com.wootecam.jspcafe.servlet.user;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class SignOutServlet extends HttpServlet {
+
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
+            throws ServletException, IOException {
+        req.getSession().invalidate();
+
+        resp.sendRedirect("/");
+    }
+}

--- a/src/main/java/com/wootecam/jspcafe/servlet/user/UserEditServlet.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/user/UserEditServlet.java
@@ -20,7 +20,8 @@ public class UserEditServlet extends HttpServlet {
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
             throws ServletException, IOException {
         Long id = parseSuffixPathVariable(req.getPathInfo());
-        User user = userService.read(id);
+        User signInUser = (User) req.getSession().getAttribute("signInUser");
+        User user = userService.readSignInUser(id, signInUser);
 
         req.setAttribute("user", user);
         req.getRequestDispatcher("/WEB-INF/views/user/update_form.jsp")

--- a/src/main/webapp/WEB-INF/views/index.jsp
+++ b/src/main/webapp/WEB-INF/views/index.jsp
@@ -24,7 +24,7 @@
                                     <i class="icon-add-comment"></i>
                                     <span class="time">
                                         <fmt:parseDate value="${question.createdTime}" pattern="yyyy-MM-dd'T'HH:mm"
-                                                       var="createdTime" type="both"/>
+                                                       var="createdTime" type="both" parseLocale="ko"/>
                                         <fmt:formatDate pattern="yyyy-MM-dd HH:mm" value="${createdTime}"/>
                                     </span>
                                     <a href="user/profile.jsp" class="author">${question.writer}</a>

--- a/src/main/webapp/WEB-INF/views/qna/form.jsp
+++ b/src/main/webapp/WEB-INF/views/qna/form.jsp
@@ -6,13 +6,15 @@
 <jsp:include page="../snippet/navigation.jsp"/>
 <jsp:include page="../snippet/header.jsp"/>
 
+<c:set var="signInUser" value="${sessionScope.signInUser}"/>
+
 <div class="container" id="main">
     <div class="col-md-12 col-sm-12 col-lg-10 col-lg-offset-1">
         <div class="panel panel-default content-main">
             <form name="question" method="post" action="${pageContext.request.contextPath}/questions">
                 <div class="form-group">
                     <label for="writer">글쓴이</label>
-                    <input class="form-control" id="writer" name="writer" placeholder="글쓴이"/>
+                    <input class="form-control" id="writer" name="writer" value="${signInUser.name}" readonly/>
                 </div>
                 <div class="form-group">
                     <label for="title">제목</label>
@@ -22,6 +24,7 @@
                     <label for="contents">내용</label>
                     <textarea name="contents" id="contents" rows="5" class="form-control"></textarea>
                 </div>
+                <input class="form-control" id="writerId" name="writerId" value="${signInUser.id}" type="hidden"/>
                 <button type="submit" class="btn btn-success clearfix pull-right">질문하기</button>
                 <div class="clearfix"/>
             </form>

--- a/src/main/webapp/WEB-INF/views/snippet/header.jsp
+++ b/src/main/webapp/WEB-INF/views/snippet/header.jsp
@@ -31,7 +31,12 @@
                     </c:when>
                     <c:otherwise>
                         <li><a href="/users/${signInUser.id}" role="button">${signInUser.name}</a></li>
-                        <li><a href="#" role="button">로그아웃</a></li>
+                        <li>
+                            <form name="logoutForm" method="post"
+                                  action="${pageContext.request.contextPath}/users/sign-out" id="logoutForm"></form>
+                            <a href="#" role="button"
+                               onclick="document.getElementById('logoutForm').submit(); return false;">로그아웃</a>
+                        </li>
                         <li><a href="/users/edit/${signInUser.id}" role="button">개인정보수정</a></li>
                     </c:otherwise>
                 </c:choose>

--- a/src/main/webapp/WEB-INF/views/snippet/header.jsp
+++ b/src/main/webapp/WEB-INF/views/snippet/header.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <div class="navbar navbar-default" id="subnav">
     <div class="col-md-12">
         <div class="navbar-header">
@@ -22,15 +23,18 @@
         </div>
         <div class="collapse navbar-collapse" id="navbar-collapse2">
             <ul class="nav navbar-nav navbar-right">
-                <li class="active"><a href="index.html">Posts</a></li>
-                <li><a href="/users/sign-in" role="button">로그인</a></li>
-                <li><a href="/users/signup" role="button">회원가입</a></li>
-                <!--
-                <li><a href="#loginModal" role="button" data-toggle="modal">로그인</a></li>
-                <li><a href="#registerModal" role="button" data-toggle="modal">회원가입</a></li>
-                -->
-                <li><a href="#" role="button">로그아웃</a></li>
-                <li><a href="#" role="button">개인정보수정</a></li>
+                <li class="active"><a href="/">Posts</a></li>
+                <c:choose>
+                    <c:when test="${sessionScope.signInUser == null}">
+                        <li><a href="/users/sign-in" role="button">로그인</a></li>
+                        <li><a href="/users/signup" role="button">회원가입</a></li>
+                    </c:when>
+                    <c:otherwise>
+                        <li><a href="/users/${signInUser.id}" role="button">${signInUser.name}</a></li>
+                        <li><a href="#" role="button">로그아웃</a></li>
+                        <li><a href="/users/edit/${signInUser.id}" role="button">개인정보수정</a></li>
+                    </c:otherwise>
+                </c:choose>
             </ul>
         </div>
     </div>

--- a/src/main/webapp/WEB-INF/views/snippet/navigation.jsp
+++ b/src/main/webapp/WEB-INF/views/snippet/navigation.jsp
@@ -27,7 +27,7 @@
                         <li><a href="https://facebook.com" target="_blank">Facebook</a></li>
                     </ul>
                 </li>
-                <li><a href="list.jsp"><i class="glyphicon glyphicon-user"></i></a></li>
+                <li><a href="/users"><i class="glyphicon glyphicon-user"></i></a></li>
             </ul>
         </div>
     </div>

--- a/src/main/webapp/WEB-INF/views/user/list.jsp
+++ b/src/main/webapp/WEB-INF/views/user/list.jsp
@@ -27,7 +27,9 @@
                         <td>${user.userId}</td>
                         <td>${user.name}</td>
                         <td>${user.email}</td>
-                        <td><a href="/users/edit/${user.id}" class="btn btn-success" role="button">수정</a></td>
+                        <c:if test="${sessionScope.signInUser != null && sessionScope.signInUser.id == user.id}">
+                            <td><a href="/users/edit/${user.id}" class="btn btn-success" role="button">수정</a></td>
+                        </c:if>
                     </tr>
                 </c:forEach>
                 </tbody>

--- a/src/test/java/com/wootecam/jspcafe/domain/QuestionTest.java
+++ b/src/test/java/com/wootecam/jspcafe/domain/QuestionTest.java
@@ -10,7 +10,7 @@ class QuestionTest {
     @Test
     void 질문_폼_입력에서_하나라도_비어있다면_예외가_발생한다() {
         // expect
-        assertThatThrownBy(() -> new Question("", "안녕하세요!", "반갑습니다.", LocalDateTime.now()))
+        assertThatThrownBy(() -> new Question("", "안녕하세요!", "반갑습니다.", LocalDateTime.now(), 1L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("질문 작성 시 모든 정보를 입력해야 합니다.");
     }
@@ -18,7 +18,7 @@ class QuestionTest {
     @Test
     void 질문_폼_입력에서_하나라도_null이_입력되면_예외가_발생한다() {
         // expect
-        assertThatThrownBy(() -> new Question("HiiWee", "안녕하세요!", null, LocalDateTime.now()))
+        assertThatThrownBy(() -> new Question("HiiWee", "안녕하세요!", null, LocalDateTime.now(), 1L))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("질문 작성 시 모든 정보를 입력해야 합니다.");
     }

--- a/src/test/java/com/wootecam/jspcafe/service/QuestionServiceTest.java
+++ b/src/test/java/com/wootecam/jspcafe/service/QuestionServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.wootecam.jspcafe.domain.Question;
+import com.wootecam.jspcafe.domain.User;
 import com.wootecam.jspcafe.service.fixture.ServiceTest;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -35,21 +36,27 @@ class QuestionServiceTest extends ServiceTest {
 
             @ParameterizedTest
             @MethodSource("generateInvalidQuestionInfo")
-            void 예외를_발생시킨다(List<String> invalidUserInfo) {
-                assertThatThrownBy(() -> questionService.append(invalidUserInfo.get(0), invalidUserInfo.get(1),
-                        invalidUserInfo.get(2)))
+            void 예외를_발생시킨다(List<Object> invalidUserInfo) {
+                // given
+                userRepository.save(new User(1L, "userId", "password", "name", "email"));
+
+                // expect
+                assertThatThrownBy(
+                        () -> questionService.append((String) invalidUserInfo.get(0), (String) invalidUserInfo.get(1),
+                                (String) invalidUserInfo.get(2), (Long) invalidUserInfo.get(3)))
                         .isInstanceOf(IllegalArgumentException.class)
                         .hasMessage("질문 작성 시 모든 정보를 입력해야 합니다.");
             }
 
             private static Stream<Arguments> generateInvalidQuestionInfo() {
                 return Stream.of(
-                        Arguments.of(List.of("", "제목입니다.", "내용입니다.")),
-                        Arguments.of(List.of("작성자", "", "내용입니다.")),
-                        Arguments.of(List.of("작성자", "제목입니다.", "")),
-                        Arguments.of(Arrays.asList(null, "제목입니다.", "내용입니다.")),
-                        Arguments.of(Arrays.asList("작성자", null, "내용입니다.")),
-                        Arguments.of(Arrays.asList("작성자", "제목입니다.", null))
+                        Arguments.of(List.of("", "제목입니다.", "내용입니다.", 1L)),
+                        Arguments.of(List.of("작성자", "", "내용입니다.", 1L)),
+                        Arguments.of(List.of("작성자", "제목입니다.", "", 1L)),
+                        Arguments.of(Arrays.asList(null, "제목입니다.", "내용입니다.", 1L)),
+                        Arguments.of(Arrays.asList("작성자", null, "내용입니다.", 1L)),
+                        Arguments.of(Arrays.asList("작성자", "제목입니다.", null, 1L)),
+                        Arguments.of(Arrays.asList("작성자", "제목입니다.", "내용입니다.", null))
                 );
             }
         }
@@ -59,9 +66,12 @@ class QuestionServiceTest extends ServiceTest {
 
             @Test
             void 질문을_저장합니다() {
+                // given
+                userRepository.save(new User(1L, "userId", "password", "name", "email"));
+
                 // expect
                 assertThatNoException()
-                        .isThrownBy(() -> questionService.append("작성자", "제목입니다.", "내용입니다."));
+                        .isThrownBy(() -> questionService.append("작성자", "제목입니다.", "내용입니다.", 1L));
             }
         }
     }
@@ -72,9 +82,10 @@ class QuestionServiceTest extends ServiceTest {
         @Test
         void 저장되어있는_모든_질문을_반환한다() {
             // given
-            questionRepository.save(new Question(1L, "작성자", "제목입니다.", "내용입니다.", LocalDateTime.now()));
-            questionRepository.save(new Question(2L, "작성자", "제목입니다.", "내용입니다.", LocalDateTime.now()));
-            questionRepository.save(new Question(3L, "작성자", "제목입니다.", "내용입니다.", LocalDateTime.now()));
+            userRepository.save(new User(1L, "userId", "password", "name", "email"));
+            questionRepository.save(new Question(1L, "작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
+            questionRepository.save(new Question(2L, "작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
+            questionRepository.save(new Question(3L, "작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
 
             // when
             List<Question> questions = questionService.readAll();
@@ -94,7 +105,8 @@ class QuestionServiceTest extends ServiceTest {
             @Test
             void id에_해당하는_질문을_반환한다() {
                 // given
-                questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now()));
+                userRepository.save(new User(1L, "userId", "password", "name", "email"));
+                questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
 
                 // when
                 Question question = questionService.read(1L);


### PR DESCRIPTION
## 구현 내용
- 로그인/비로그인 상태 시 헤더에 표시되는 상태를 다르게 함
  - `로그인`: 이름, 로그아웃, 개인정보수정
  - `비로그인`: 로그인, 회원가입
- 로그아웃 기능 추가
  - `session.invalidate()`
- 로그인한 사용자만 질문을 작성할 수 있습니다.
  - 로그인을 하지 않았다면 로그인 화면으로 리다이렉트 합니다.

## 고민 사항 및 결정 과정
![image](https://github.com/user-attachments/assets/cc85f3b0-702c-4e74-9d28-64119d8635b6)

- `가능한 방법`
    1. 수정 버튼을 현재 로그인한 사용자의 PK값인 id와 일치하면 보이도록 하는 방법
    2. 수정 버튼을 눌렀을때 서버에서 로그인한 사용자와 수정하려는 사용자가 일치하는지 판단하는 방법
- `내가 생각한 단점`
    1. 수정 버튼을 눌렀을때 `GET /users/edit/{id}`로 요청이 감, 다른 사용자의 id를 임의로 넣어서 수정 폼으로 이동할 수 있게됨
    2. 모든 버튼에 수정 버튼이 보이게 되니 사용자는 헷갈릴 수 있다고 판단했습니다.
- `결정`
    
    1 + 2번의 방법을 같이 묶어서 하는편이 좋아보임 → 사용자는 어떤 버튼을 클릭해야 할지 가시적으로 보이면서, 서버 측에선 혹여나 들어오는 잘못된 요청을 막을 수 있기 때문입니다.
    ![image](https://github.com/user-attachments/assets/910f2d72-630f-40e7-8999-94be363fe9ff)

## 기타
우테캠 7기 화이팅입니다!!!!
