### PR TITLE
[김현욱] step-5 게시글 권한부여

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     // https://mvnrepository.com/artifact/com.mysql/mysql-connector-j
     implementation 'com.mysql:mysql-connector-j:8.4.0'
 
+// https://mvnrepository.com/artifact/com.h2database/h2
+    testImplementation 'com.h2database:h2:2.3.230'
 
     // https://mvnrepository.com/artifact/jakarta.servlet.jsp/jakarta.servlet.jsp-api
     compileOnly 'jakarta.servlet.jsp:jakarta.servlet.jsp-api:4.0.0'

--- a/src/main/java/com/hyeonuk/jspcafe/article/dao/ArticleDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/dao/ArticleDao.java
@@ -9,4 +9,5 @@ public interface ArticleDao {
     Article save(Article article);
     List<Article> findAll();
     Optional<Article> findById(Long id);
+    void deleteById(Long id);
 }

--- a/src/main/java/com/hyeonuk/jspcafe/article/dao/InMemoryArticleDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/dao/InMemoryArticleDao.java
@@ -41,4 +41,9 @@ public class InMemoryArticleDao implements ArticleDao{
                 .filter(article->article.getId().equals(id))
                 .findFirst();
     }
+
+    @Override
+    public void deleteById(Long id) {
+        store.remove(id);
+    }
 }

--- a/src/main/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDao.java
@@ -1,9 +1,8 @@
 package com.hyeonuk.jspcafe.article.dao;
 
 import com.hyeonuk.jspcafe.article.domain.Article;
-import com.hyeonuk.jspcafe.global.db.mysql.MysqlManager;
+import com.hyeonuk.jspcafe.global.db.mysql.DBManager;
 import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
-import com.hyeonuk.jspcafe.member.domain.Member;
 
 import java.sql.*;
 import java.util.ArrayList;
@@ -11,9 +10,9 @@ import java.util.List;
 import java.util.Optional;
 
 public class MysqlArticleDao implements ArticleDao{
-    private final MysqlManager manager;
+    private final DBManager manager;
 
-    public MysqlArticleDao(MysqlManager manager) {
+    public MysqlArticleDao(DBManager manager) {
         this.manager = manager;
     }
 

--- a/src/main/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDao.java
@@ -106,6 +106,19 @@ public class MysqlArticleDao implements ArticleDao{
         }
     }
 
+    @Override
+    public void deleteById(Long id) {
+        try(Connection conn = manager.getConnection()){
+            String sql = "delete from article where id = ?";
+            PreparedStatement pstmt = conn.prepareStatement(sql);
+            pstmt.setLong(1, id);
+
+            pstmt.executeUpdate();
+        }catch(SQLException e){
+            throw new DataIntegrityViolationException("error");
+        }
+    }
+
     private Article mappingArticle(ResultSet rs) throws SQLException {
         Long id = rs.getLong("id");
         String writer = rs.getString("writer");

--- a/src/main/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDao.java
@@ -1,7 +1,8 @@
 package com.hyeonuk.jspcafe.article.dao;
 
 import com.hyeonuk.jspcafe.article.domain.Article;
-import com.hyeonuk.jspcafe.global.db.mysql.DBManager;
+import com.hyeonuk.jspcafe.global.db.DBManager;
+import com.hyeonuk.jspcafe.global.db.DBManagerIml;
 import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
 
 import java.sql.*;

--- a/src/main/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServlet.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServlet.java
@@ -11,9 +11,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.util.Arrays;
 
-public class ArticleViewServlet extends HttpServlet {
+public class ArticleControlServlet extends HttpServlet {
     private ArticleDao articleDao;
     @Override
     public void init(ServletConfig config) throws ServletException {

--- a/src/main/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServlet.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServlet.java
@@ -89,7 +89,12 @@ public class ArticleControlServlet extends HttpServlet {
             }
             else if("DELETE".equalsIgnoreCase(method)){
                 //삭제 메서드
+                articleDao.deleteById(articleId);
 
+                resp.sendRedirect("/");
+            }
+            else{
+                throw new HttpBadRequestException("잘못된 요청입니다.");
             }
 
         }catch(NumberFormatException e ){

--- a/src/main/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServlet.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServlet.java
@@ -4,11 +4,13 @@ import com.hyeonuk.jspcafe.article.dao.ArticleDao;
 import com.hyeonuk.jspcafe.article.domain.Article;
 import com.hyeonuk.jspcafe.global.exception.HttpBadRequestException;
 import com.hyeonuk.jspcafe.global.exception.HttpNotFoundException;
+import com.hyeonuk.jspcafe.member.domain.Member;
 import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import java.io.IOException;
 
@@ -23,6 +25,42 @@ public class ArticleControlServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         String pathInfo = req.getPathInfo();
+        if(pathInfo == null || "/".equals(pathInfo)) {
+            throw new HttpBadRequestException("잘못된 요청입니다.");
+        }
+        String[] pathParts = pathInfo.split("/");
+        if(pathParts.length < 2){
+            throw new HttpBadRequestException("잘못된 요청입니다.");
+        }
+        try {
+            Long articleId = Long.parseLong(pathParts[1]);
+
+            Article article = articleDao.findById(articleId)
+                    .orElseThrow(() -> new HttpNotFoundException(articleId + "번의 게시글을 찾을 수 없습니다."));
+            req.setAttribute("article",article);
+
+            if(pathParts.length == 2) {
+                req.getRequestDispatcher("/templates/qna/show.jsp").forward(req, resp);
+            }
+            else if(pathParts.length == 3 && "form".equals(pathParts[2])){
+                HttpSession session = req.getSession();
+                Member member = (Member)session.getAttribute("member");
+                if(!article.getWriter().equals(member.getMemberId())) {
+                    throw new HttpBadRequestException("작성자가 아닙니다.");
+                }
+                req.getRequestDispatcher("/templates/qna/modify.jsp").forward(req, resp);
+            }
+            else {
+                throw new HttpBadRequestException("잘못된 요청입니다.");
+            }
+        }catch(NumberFormatException e ){
+            throw new HttpBadRequestException("잘못된 요청입니다.");
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String pathInfo = req.getPathInfo();
         if(pathInfo == null || pathInfo.isEmpty() || pathInfo.split("/").length != 2) {
             throw new HttpBadRequestException("잘못된 요청입니다.");
         }
@@ -31,8 +69,29 @@ public class ArticleControlServlet extends HttpServlet {
 
             Article article = articleDao.findById(articleId)
                     .orElseThrow(() -> new HttpNotFoundException(articleId + "번의 게시글을 찾을 수 없습니다."));
-            req.setAttribute("article",article);
-            req.getRequestDispatcher("/templates/qna/show.jsp").forward(req, resp);
+
+            Member member = (Member)req.getSession().getAttribute("member");
+            if(!article.getWriter().equals(member.getMemberId())) throw new HttpBadRequestException("작성자가 아니라 권한이 없습니다.");
+
+            String method = req.getParameter("_method");
+            if("PUT".equalsIgnoreCase(method)){
+                //수정 메서드
+                String title = req.getParameter("title");
+                String contents = req.getParameter("contents");
+
+                article.setContents(contents);
+                article.setTitle(title);
+
+                if(!article.validation()) throw new HttpBadRequestException("빈 값이 있으면 안됩니다.");
+
+                articleDao.save(article);
+                resp.sendRedirect("/questions/"+article.getId());
+            }
+            else if("DELETE".equalsIgnoreCase(method)){
+                //삭제 메서드
+
+            }
+
         }catch(NumberFormatException e ){
             throw new HttpBadRequestException("잘못된 요청입니다.");
         }

--- a/src/main/java/com/hyeonuk/jspcafe/global/db/DBConnectionInfo.java
+++ b/src/main/java/com/hyeonuk/jspcafe/global/db/DBConnectionInfo.java
@@ -1,0 +1,56 @@
+package com.hyeonuk.jspcafe.global.db;
+
+import com.hyeonuk.jspcafe.utils.Yaml;
+import com.hyeonuk.jspcafe.utils.YamlParser;
+
+public class DBConnectionInfo {
+    private final String url;
+    private final String username;
+    private final String password;
+    private final String driverClassName;
+
+    public DBConnectionInfo(String url, String username, String password, String driverClassName) {
+        validation(url,username,password,driverClassName);
+        this.url = url;
+        this.username = username;
+        this.password = password;
+        this.driverClassName = driverClassName;
+    }
+
+    public DBConnectionInfo(String yamlPath) {
+        YamlParser yamlParser = new YamlParser();
+        Yaml yaml = yamlParser.parse(yamlPath);
+
+        String url = yaml.getString("db.datasource.url");
+        String username = yaml.getString("db.datasource.username");
+        String password = yaml.getString("db.datasource.password");
+        String driverClassName = yaml.getString("db.datasource.driver-class-name");
+        validation(url,username,password,driverClassName);
+        this.url = url;
+        this.username = username;
+        this.password = password;
+        this.driverClassName = driverClassName;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getDriverClassName() {
+        return driverClassName;
+    }
+
+    private void validation(String url, String username, String password, String driverClassName){
+        if(url == null || username == null || password == null || driverClassName == null){
+            throw new IllegalArgumentException("url, username, password and driverClassName must not be null");
+        }
+    }
+}

--- a/src/main/java/com/hyeonuk/jspcafe/global/db/DBManagerIml.java
+++ b/src/main/java/com/hyeonuk/jspcafe/global/db/DBManagerIml.java
@@ -1,15 +1,13 @@
-package com.hyeonuk.jspcafe.global.db.mysql;
-
-import com.hyeonuk.jspcafe.global.db.DBConnectionInfo;
+package com.hyeonuk.jspcafe.global.db;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.sql.*;
 
-public class DBManager implements com.hyeonuk.jspcafe.global.db.DBManager {
+public class DBManagerIml implements DBManager {
     private final DBConnectionInfo connectionInfo;
-    public DBManager(DBConnectionInfo connectionInfo) throws ClassNotFoundException, SQLException {
+    public DBManagerIml(DBConnectionInfo connectionInfo) throws ClassNotFoundException, SQLException {
         this.connectionInfo = connectionInfo;
         Class.forName(connectionInfo.getDriverClassName());
         try(Connection conn = getConnection()) {
@@ -22,7 +20,7 @@ public class DBManager implements com.hyeonuk.jspcafe.global.db.DBManager {
     }
     private String readSqlFile(String fileName) {
         StringBuilder sb = new StringBuilder();
-        try (InputStream is = DBManager.class.getClassLoader().getResourceAsStream(fileName);
+        try (InputStream is = DBManagerIml.class.getClassLoader().getResourceAsStream(fileName);
              BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
             String line;
             while ((line = reader.readLine()) != null) {

--- a/src/main/java/com/hyeonuk/jspcafe/global/db/mysql/DBManager.java
+++ b/src/main/java/com/hyeonuk/jspcafe/global/db/mysql/DBManager.java
@@ -1,39 +1,28 @@
 package com.hyeonuk.jspcafe.global.db.mysql;
 
-import com.hyeonuk.jspcafe.global.db.DBManager;
-import com.hyeonuk.jspcafe.utils.Yaml;
-import com.hyeonuk.jspcafe.utils.YamlParser;
+import com.hyeonuk.jspcafe.global.db.DBConnectionInfo;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.sql.*;
 
-public class MysqlManager implements DBManager {
-    private final String url;
-    private final String username;
-    private final String password;
-    public MysqlManager() throws ClassNotFoundException, SQLException {
-        YamlParser yamlParser = new YamlParser();
-        Yaml yaml = yamlParser.parse("application-db.yml");
-
-        url = yaml.getString("db.datasource.url");
-        username = yaml.getString("db.datasource.username");
-        password = yaml.getString("db.datasource.password");
-        String driver = yaml.getString("db.datasource.driver-class-name");
-
-        Class.forName(driver);
+public class DBManager implements com.hyeonuk.jspcafe.global.db.DBManager {
+    private final DBConnectionInfo connectionInfo;
+    public DBManager(DBConnectionInfo connectionInfo) throws ClassNotFoundException, SQLException {
+        this.connectionInfo = connectionInfo;
+        Class.forName(connectionInfo.getDriverClassName());
         try(Connection conn = getConnection()) {
             executeSqlScript(conn,"init.sql");
         }
     }
 
     public Connection getConnection() throws SQLException {
-        return DriverManager.getConnection(url,username,password);
+        return DriverManager.getConnection(connectionInfo.getUrl(),connectionInfo.getUsername(),connectionInfo.getPassword());
     }
     private String readSqlFile(String fileName) {
         StringBuilder sb = new StringBuilder();
-        try (InputStream is = MysqlManager.class.getClassLoader().getResourceAsStream(fileName);
+        try (InputStream is = DBManager.class.getClassLoader().getResourceAsStream(fileName);
              BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
             String line;
             while ((line = reader.readLine()) != null) {
@@ -51,7 +40,7 @@ public class MysqlManager implements DBManager {
         for (String sql : sqls) {
             try(PreparedStatement pstmt = conn.prepareStatement(sql)) {
                 if (!sql.trim().isEmpty()) {
-                    pstmt.execute(sql);
+                    pstmt.execute();
                 }
             }
         }

--- a/src/main/java/com/hyeonuk/jspcafe/global/servlet/MyServletContextListener.java
+++ b/src/main/java/com/hyeonuk/jspcafe/global/servlet/MyServletContextListener.java
@@ -3,7 +3,8 @@ package com.hyeonuk.jspcafe.global.servlet;
 import com.hyeonuk.jspcafe.article.dao.ArticleDao;
 import com.hyeonuk.jspcafe.article.dao.MysqlArticleDao;
 import com.hyeonuk.jspcafe.global.db.DBConnectionInfo;
-import com.hyeonuk.jspcafe.global.db.mysql.DBManager;
+import com.hyeonuk.jspcafe.global.db.DBManager;
+import com.hyeonuk.jspcafe.global.db.DBManagerIml;
 import com.hyeonuk.jspcafe.global.exception.HttpInternalServerErrorException;
 import com.hyeonuk.jspcafe.global.utils.BcryptPasswordEncoder;
 import com.hyeonuk.jspcafe.global.utils.PasswordEncoder;
@@ -21,7 +22,7 @@ public class MyServletContextListener implements ServletContextListener{
         ServletContextListener.super.contextInitialized(sce);
         try {
             DBConnectionInfo connectionInfo = new DBConnectionInfo("application-db.yml");
-            DBManager dbManager = new DBManager(connectionInfo);
+            DBManager dbManager = new DBManagerIml(connectionInfo);
             memberDao = new MysqlMemberDao(dbManager);
             passwordEncoder = new BcryptPasswordEncoder();
             articleDao = new MysqlArticleDao(dbManager);

--- a/src/main/java/com/hyeonuk/jspcafe/global/servlet/MyServletContextListener.java
+++ b/src/main/java/com/hyeonuk/jspcafe/global/servlet/MyServletContextListener.java
@@ -1,19 +1,16 @@
 package com.hyeonuk.jspcafe.global.servlet;
 
 import com.hyeonuk.jspcafe.article.dao.ArticleDao;
-import com.hyeonuk.jspcafe.article.dao.InMemoryArticleDao;
 import com.hyeonuk.jspcafe.article.dao.MysqlArticleDao;
-import com.hyeonuk.jspcafe.global.db.mysql.MysqlManager;
+import com.hyeonuk.jspcafe.global.db.DBConnectionInfo;
+import com.hyeonuk.jspcafe.global.db.mysql.DBManager;
 import com.hyeonuk.jspcafe.global.exception.HttpInternalServerErrorException;
 import com.hyeonuk.jspcafe.global.utils.BcryptPasswordEncoder;
 import com.hyeonuk.jspcafe.global.utils.PasswordEncoder;
-import com.hyeonuk.jspcafe.member.dao.InMemoryMemberDao;
 import com.hyeonuk.jspcafe.member.dao.MemberDao;
 import com.hyeonuk.jspcafe.member.dao.MysqlMemberDao;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
-
-import java.sql.SQLException;
 
 public class MyServletContextListener implements ServletContextListener{
     private MemberDao memberDao;
@@ -23,7 +20,8 @@ public class MyServletContextListener implements ServletContextListener{
     public void contextInitialized(ServletContextEvent sce) {
         ServletContextListener.super.contextInitialized(sce);
         try {
-            MysqlManager dbManager = new MysqlManager();
+            DBConnectionInfo connectionInfo = new DBConnectionInfo("application-db.yml");
+            DBManager dbManager = new DBManager(connectionInfo);
             memberDao = new MysqlMemberDao(dbManager);
             passwordEncoder = new BcryptPasswordEncoder();
             articleDao = new MysqlArticleDao(dbManager);

--- a/src/main/java/com/hyeonuk/jspcafe/member/dao/MysqlMemberDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/member/dao/MysqlMemberDao.java
@@ -1,6 +1,6 @@
 package com.hyeonuk.jspcafe.member.dao;
 
-import com.hyeonuk.jspcafe.global.db.mysql.MysqlManager;
+import com.hyeonuk.jspcafe.global.db.mysql.DBManager;
 import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
 import com.hyeonuk.jspcafe.member.domain.Member;
 
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Optional;
 
 public class MysqlMemberDao implements MemberDao {
-    private final MysqlManager manager;
-    public MysqlMemberDao(MysqlManager manager) {
+    private final DBManager manager;
+    public MysqlMemberDao(DBManager manager) {
         this.manager = manager;
     }
 
@@ -68,7 +68,6 @@ public class MysqlMemberDao implements MemberDao {
             }
             return member;
         }catch (SQLException e) {
-            e.printStackTrace();
             throw new DataIntegrityViolationException("error");
         }
     }
@@ -102,6 +101,7 @@ public class MysqlMemberDao implements MemberDao {
             }
             return members;
         } catch (SQLException e) {
+            e.printStackTrace();
             throw new DataIntegrityViolationException("error");
         }
     }

--- a/src/main/java/com/hyeonuk/jspcafe/member/dao/MysqlMemberDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/member/dao/MysqlMemberDao.java
@@ -1,6 +1,7 @@
 package com.hyeonuk.jspcafe.member.dao;
 
-import com.hyeonuk.jspcafe.global.db.mysql.DBManager;
+import com.hyeonuk.jspcafe.global.db.DBManager;
+import com.hyeonuk.jspcafe.global.db.DBManagerIml;
 import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
 import com.hyeonuk.jspcafe.member.domain.Member;
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -36,11 +36,11 @@
     </servlet-mapping>
 
     <servlet>
-        <servlet-name>articleViewServlet</servlet-name>
-        <servlet-class>com.hyeonuk.jspcafe.article.servlet.ArticleViewServlet</servlet-class>
+        <servlet-name>articleControlServlet</servlet-name>
+        <servlet-class>com.hyeonuk.jspcafe.article.servlet.ArticleControlServlet</servlet-class>
     </servlet>
     <servlet-mapping>
-        <servlet-name>articleViewServlet</servlet-name>
+        <servlet-name>articleControlServlet</servlet-name>
         <url-pattern>/questions/*</url-pattern>
     </servlet-mapping>
     <servlet>
@@ -51,7 +51,7 @@
         <servlet-name>articleRegisterServlet</servlet-name>
         <url-pattern>/questions/regist</url-pattern>
     </servlet-mapping>
-    
+
     <servlet>
         <servlet-name>memberLoginServlet</servlet-name>
         <servlet-class>com.hyeonuk.jspcafe.member.servlets.MemberLoginServlet</servlet-class>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -49,7 +49,7 @@
     </servlet>
     <servlet-mapping>
         <servlet-name>articleRegisterServlet</servlet-name>
-        <url-pattern>/questions</url-pattern>
+        <url-pattern>/questions/regist</url-pattern>
     </servlet-mapping>
     
     <servlet>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -80,7 +80,7 @@
     <filter-mapping>
         <filter-name>sessionFilter</filter-name>
         <url-pattern>/members/*/form</url-pattern>
-        <url-pattern>/questions</url-pattern>
+        <url-pattern>/questions/*</url-pattern>
     </filter-mapping>
 
     <filter>

--- a/src/main/webapp/qnaList.jsp
+++ b/src/main/webapp/qnaList.jsp
@@ -48,7 +48,7 @@
                 </ul>
               </div>
               <div class="col-md-3 qna-write">
-                  <a href="${pageContext.request.contextPath}/questions" class="btn btn-primary pull-right" role="button">질문하기</a>
+                  <a href="${pageContext.request.contextPath}/questions/regist" class="btn btn-primary pull-right" role="button">질문하기</a>
               </div>
           </div>
         </div>

--- a/src/main/webapp/templates/qna/form.jsp
+++ b/src/main/webapp/templates/qna/form.jsp
@@ -6,7 +6,7 @@
 <div class="container" id="main">
    <div class="col-md-12 col-sm-12 col-lg-10 col-lg-offset-1">
       <div class="panel panel-default content-main">
-          <form name="question" method="post" action="${pageContext.request.contextPath}/questions">
+          <form name="question" method="post" action="${pageContext.request.contextPath}/questions/regist">
               <div class="form-group">
                   <label for="title">제목</label>
                   <input type="text" class="form-control" id="title" name="title" placeholder="제목"/>

--- a/src/main/webapp/templates/qna/modify.jsp
+++ b/src/main/webapp/templates/qna/modify.jsp
@@ -1,0 +1,35 @@
+<%@ page import="com.hyeonuk.jspcafe.article.domain.Article" %>
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ include file="../component/header.jsp"%>
+<!DOCTYPE html>
+<html lang="kr">
+<body>
+<div class="container" id="main">
+   <div class="col-md-12 col-sm-12 col-lg-10 col-lg-offset-1">
+      <div class="panel panel-default content-main">
+          <%
+              Article article = (Article) request.getAttribute("article");
+          %>
+          <form name="question" method="post" action="${pageContext.request.contextPath}/questions/<%=article.getId()%>">
+              <input type="hidden" name="_method" value="PUT"/>
+              <div class="form-group">
+                  <label for="title">제목</label>
+                  <input type="text" class="form-control" id="title" name="title" placeholder="제목" value="<%=article.getTitle()%>"/>
+              </div>
+              <div class="form-group">
+                  <label for="contents">내용</label>
+                  <textarea name="contents" id="contents" rows="5" class="form-control"><%=article.getContents()%></textarea>
+              </div>
+              <button type="submit" class="btn btn-success clearfix pull-right">수정하기</button>
+              <div class="clearfix" />
+          </form>
+        </div>
+    </div>
+</div>
+
+<!-- script references -->
+<script src="../js/jquery-2.2.0.min.js"></script>
+<script src="../js/bootstrap.min.js"></script>
+<script src="../js/scripts.js"></script>
+	</body>
+</html>

--- a/src/main/webapp/templates/qna/show.jsp
+++ b/src/main/webapp/templates/qna/show.jsp
@@ -33,10 +33,10 @@
                   <div class="article-util">
                       <ul class="article-util-list">
                           <li>
-                              <a class="link-modify-article" href="/questions/423/form">수정</a>
+                              <a class="link-modify-article" href="/questions/<%=article.getId()%>/form">수정</a>
                           </li>
                           <li>
-                              <form class="form-delete" action="/questions/423" method="POST">
+                              <form class="form-delete" action="/questions/<%=article.getId()%>" method="POST">
                                   <input type="hidden" name="_method" value="DELETE">
                                   <button class="link-delete-article" type="submit">삭제</button>
                               </form>

--- a/src/main/webapp/templates/qna/show.jsp
+++ b/src/main/webapp/templates/qna/show.jsp
@@ -7,6 +7,7 @@
 <div class="container" id="main">
     <%
         Article article = (Article)request.getAttribute("article");
+        Member member = (Member)session.getAttribute("member");
     %>
     <div class="col-md-12 col-sm-12 col-lg-12">
         <div class="panel panel-default">
@@ -32,6 +33,9 @@
                   </div>
                   <div class="article-util">
                       <ul class="article-util-list">
+                          <%
+                              if(article.getWriter().equals(member.getMemberId())){
+                          %>
                           <li>
                               <a class="link-modify-article" href="/questions/<%=article.getId()%>/form">수정</a>
                           </li>
@@ -41,8 +45,11 @@
                                   <button class="link-delete-article" type="submit">삭제</button>
                               </form>
                           </li>
+                         <%
+                             }
+                         %>
                           <li>
-                              <a class="link-modify-article" href="/index.jsp">목록</a>
+                              <a class="link-modify-article" href="/">목록</a>
                           </li>
                       </ul>
                   </div>

--- a/src/test/java/com/hyeonuk/jspcafe/article/dao/InMemoryArticleDaoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/dao/InMemoryArticleDaoTest.java
@@ -139,4 +139,22 @@ class InMemoryArticleDaoTest {
             assertFalse(foundArticle.isPresent());
         }
     }
+
+    @Nested
+    @DisplayName("deleteById 메서드는")
+    class DeleteById{
+        @Test
+        @DisplayName("존재하는 article id면 삭제한다.")
+        void deleteArticleByIdSuccess() throws Exception{
+            //given
+            Article article = new Article(1l,"writer","title","contents");
+            articleDao.save(article);
+
+            //when
+            articleDao.deleteById(article.getId());
+
+            //then
+            assertTrue(articleDao.findById(article.getId()).isEmpty());
+        }
+    }
 }

--- a/src/test/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDaoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDaoTest.java
@@ -1,9 +1,9 @@
 package com.hyeonuk.jspcafe.article.dao;
 
 import com.hyeonuk.jspcafe.article.domain.Article;
-import com.hyeonuk.jspcafe.global.db.mysql.MysqlManager;
+import com.hyeonuk.jspcafe.global.db.DBConnectionInfo;
+import com.hyeonuk.jspcafe.global.db.mysql.DBManager;
 import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
-import com.mysql.cj.jdbc.MysqlDataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,7 +20,8 @@ class MysqlArticleDaoTest {
 
     @BeforeEach
     void setUp() throws SQLException, ClassNotFoundException {
-        MysqlManager manager = new MysqlManager();
+        DBConnectionInfo connectionInfo = new DBConnectionInfo("application-testdb.yml");
+        DBManager manager = new DBManager(connectionInfo);
         articleDao = new MysqlArticleDao(manager);
     }
 

--- a/src/test/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDaoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDaoTest.java
@@ -2,7 +2,7 @@ package com.hyeonuk.jspcafe.article.dao;
 
 import com.hyeonuk.jspcafe.article.domain.Article;
 import com.hyeonuk.jspcafe.global.db.DBConnectionInfo;
-import com.hyeonuk.jspcafe.global.db.mysql.DBManager;
+import com.hyeonuk.jspcafe.global.db.DBManagerIml;
 import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +21,7 @@ class MysqlArticleDaoTest {
     @BeforeEach
     void setUp() throws SQLException, ClassNotFoundException {
         DBConnectionInfo connectionInfo = new DBConnectionInfo("application-testdb.yml");
-        DBManager manager = new DBManager(connectionInfo);
+        DBManagerIml manager = new DBManagerIml(connectionInfo);
         articleDao = new MysqlArticleDao(manager);
     }
 

--- a/src/test/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDaoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDaoTest.java
@@ -143,4 +143,22 @@ class MysqlArticleDaoTest {
             assertFalse(foundArticle.isPresent());
         }
     }
+
+    @Nested
+    @DisplayName("deleteById 메서드는")
+    class DeleteById{
+        @Test
+        @DisplayName("존재하는 article id면 삭제한다.")
+        void deleteArticleByIdSuccess() throws Exception{
+            //given
+            Article article = new Article(1l,"writer","title","contents");
+            articleDao.save(article);
+
+            //when
+            articleDao.deleteById(article.getId());
+
+            //then
+            assertTrue(articleDao.findById(article.getId()).isEmpty());
+        }
+    }
 }

--- a/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServletTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServletTest.java
@@ -23,18 +23,18 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("ArticleViewServlet 클래스")
-class ArticleViewServletTest {
+class ArticleControlServletTest {
     private MockRequest req;
     private MockResponse res;
     private ArticleDao articleDao;
-    private ArticleViewServlet servlet;
+    private ArticleControlServlet servlet;
 
     @BeforeEach
     void setUp() throws ServletException {
         req = new MockRequest();
         res = new MockResponse();
         articleDao = new InMemoryArticleDao();
-        servlet = new ArticleViewServlet();
+        servlet = new ArticleControlServlet();
         ServletContext servletContext = new MockServletContext();
         servletContext.setAttribute("articleDao", articleDao);
         ServletConfig servletConfig = new BaseServletConfig(servletContext);

--- a/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServletTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServletTest.java
@@ -5,11 +5,10 @@ import com.hyeonuk.jspcafe.article.dao.InMemoryArticleDao;
 import com.hyeonuk.jspcafe.article.domain.Article;
 import com.hyeonuk.jspcafe.global.exception.HttpBadRequestException;
 import com.hyeonuk.jspcafe.global.exception.HttpNotFoundException;
-import com.hyeonuk.jspcafe.member.servlets.mock.BaseHttpServletRequest;
-import com.hyeonuk.jspcafe.member.servlets.mock.BaseHttpServletResponse;
-import com.hyeonuk.jspcafe.member.servlets.mock.BaseServletConfig;
-import com.hyeonuk.jspcafe.member.servlets.mock.MockServletContext;
+import com.hyeonuk.jspcafe.member.domain.Member;
+import com.hyeonuk.jspcafe.member.servlets.mock.*;
 import jakarta.servlet.*;
+import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -19,6 +18,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -71,6 +71,57 @@ class ArticleControlServletTest {
         }
 
         @Test
+        @DisplayName("작성자가 자신의 게시글의 /{id}/form 으로 들어온 경우")
+        void formPath() throws Exception {
+            //given
+            Article article1 = new Article(1l, "writer1", "title1", "content1");
+            Article article2 = new Article(2l, "writer2", "title2", "content2");
+            Article article3 = new Article(3l, "writer3", "title3", "content3");
+            Article article4 = new Article(4l, "writer4", "title4", "content4");
+            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            List<Article> articles = List.of(article1, article2, article3, article4, article5);
+            articles.forEach(articleDao::save);
+            req.setPathInfo("/1/form");
+            MockSession session = new MockSession();
+            session.setAttribute("member",new Member(1l,"writer1","pw1","nick1","email1"));
+            req.setSession(session);
+
+            //when
+            servlet.doGet(req, res);
+
+            //then
+            assertNotNull(req.getAttribute("article"));
+            Article article = (Article) req.getAttribute("article");
+            assertEquals(article1.getId(), article.getId());
+            assertEquals(article1.getTitle(), article.getTitle());
+            assertEquals(article1.getWriter(), article.getWriter());
+            assertEquals(article1.getContents(), article.getContents());
+            assertEquals("/templates/qna/modify.jsp", req.getForwardPath());
+        }
+
+        @Test
+        @DisplayName("작성자가 자신이 아닌 게시글의 /{id}/form 으로 들어온 경우")
+        void formPathWithOtherArticle() throws Exception {
+            //given
+            Article article1 = new Article(1l, "writer1", "title1", "content1");
+            Article article2 = new Article(2l, "writer2", "title2", "content2");
+            Article article3 = new Article(3l, "writer3", "title3", "content3");
+            Article article4 = new Article(4l, "writer4", "title4", "content4");
+            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            List<Article> articles = List.of(article1, article2, article3, article4, article5);
+            articles.forEach(articleDao::save);
+            req.setPathInfo("/1/form");
+            MockSession session = new MockSession();
+            session.setAttribute("member",new Member(2l,"writer2","pw1","nick1","email1"));
+            req.setSession(session);
+
+            //when & then
+            assertThrows(HttpBadRequestException.class,()->{
+                servlet.doGet(req, res);
+            });
+        }
+
+        @Test
         @DisplayName("pathInfo가 null인 경우")
         void nullPathInfo() throws Exception {
             //given
@@ -109,7 +160,28 @@ class ArticleControlServletTest {
         }
 
         @Test
-        @DisplayName("pathInfo가 /{id}/{anyString}으로 들어온 경우")
+        @DisplayName("pathInfo가 /인  경우")
+        void slashPathInfo() throws Exception {
+            //given
+            Article article1 = new Article(1l, "writer1", "title1", "content1");
+            Article article2 = new Article(2l, "writer2", "title2", "content2");
+            Article article3 = new Article(3l, "writer3", "title3", "content3");
+            Article article4 = new Article(4l, "writer4", "title4", "content4");
+            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            List<Article> articles = List.of(article1, article2, article3, article4, article5);
+            articles.forEach(articleDao::save);
+            req.setPathInfo("/");
+
+            //when & then
+            assertThrows(HttpBadRequestException.class, () -> {
+                servlet.doGet(req, res);
+            });
+        }
+
+
+
+        @Test
+        @DisplayName("pathInfo가 /{id}/{anyNumber}으로 들어온 경우")
         void manyPathVariables() throws Exception {
             //given
             Article article1 = new Article(1l, "writer1", "title1", "content1");
@@ -120,6 +192,44 @@ class ArticleControlServletTest {
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo("/1/2");
+
+            //when & then
+            assertThrows(HttpBadRequestException.class, () -> {
+                servlet.doGet(req, res);
+            });
+        }
+
+        @Test
+        @DisplayName("pathInfo가 /{id}/{form 이외의 string}으로 들어온 경우")
+        void manyPathVariablesWithString() throws Exception {
+            //given
+            Article article1 = new Article(1l, "writer1", "title1", "content1");
+            Article article2 = new Article(2l, "writer2", "title2", "content2");
+            Article article3 = new Article(3l, "writer3", "title3", "content3");
+            Article article4 = new Article(4l, "writer4", "title4", "content4");
+            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            List<Article> articles = List.of(article1, article2, article3, article4, article5);
+            articles.forEach(articleDao::save);
+            req.setPathInfo("/1/anyString");
+
+            //when & then
+            assertThrows(HttpBadRequestException.class, () -> {
+                servlet.doGet(req, res);
+            });
+        }
+
+        @Test
+        @DisplayName("pathInfo가 /{id}/{anyString}/{anyString}으로 들어온 경우")
+        void manyPathVariablesWithStringDouble() throws Exception {
+            //given
+            Article article1 = new Article(1l, "writer1", "title1", "content1");
+            Article article2 = new Article(2l, "writer2", "title2", "content2");
+            Article article3 = new Article(3l, "writer3", "title3", "content3");
+            Article article4 = new Article(4l, "writer4", "title4", "content4");
+            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            List<Article> articles = List.of(article1, article2, article3, article4, article5);
+            articles.forEach(articleDao::save);
+            req.setPathInfo("/1/anyString/otherString");
 
             //when & then
             assertThrows(HttpBadRequestException.class, () -> {
@@ -166,12 +276,328 @@ class ArticleControlServletTest {
         }
     }
 
+    @Nested
+    @DisplayName("doPost 메서드")
+    class DoPost{
+        @Nested
+        @DisplayName("공통적으로 처리되는 경우")
+        class Common{
+            @Test
+            @DisplayName("pathInfo가 null인 경우")
+            void nullPathInfo() throws Exception {
+                //given
+                req.setPathInfo(null);
+
+                //when & then
+                assertThrows(HttpBadRequestException.class, () -> {
+                    servlet.doPost(req, res);
+                });
+            }
+
+            @Test
+            @DisplayName("pathInfo가 empty인 경우")
+            void emptyPathInfo() throws Exception {
+                //given
+                req.setPathInfo("");
+
+                //when & then
+                assertThrows(HttpBadRequestException.class, () -> {
+                    servlet.doPost(req, res);
+                });
+            }
+
+            @Test
+            @DisplayName("pathInfo가 /인  경우")
+            void slashPathInfo() throws Exception {
+                //given
+                req.setPathInfo("/");
+
+                //when & then
+                assertThrows(HttpBadRequestException.class, () -> {
+                    servlet.doPost(req, res);
+                });
+            }
+
+
+
+            @Test
+            @DisplayName("pathInfo가 /{id}/{anyNumber}으로 들어온 경우")
+            void manyPathVariables() throws Exception {
+                //given
+                req.setPathInfo("/1/2");
+
+                //when & then
+                assertThrows(HttpBadRequestException.class, () -> {
+                    servlet.doPost(req, res);
+                });
+            }
+
+            @Test
+            @DisplayName("pathInfo가 /{id}/{anyString}으로 들어온 경우")
+            void manyPathVariablesWithString() throws Exception {
+                //given
+                Article article1 = new Article(1l, "writer1", "title1", "content1");
+                Article article2 = new Article(2l, "writer2", "title2", "content2");
+                Article article3 = new Article(3l, "writer3", "title3", "content3");
+                Article article4 = new Article(4l, "writer4", "title4", "content4");
+                Article article5 = new Article(5l, "writer5", "title5", "content5");
+                List<Article> articles = List.of(article1, article2, article3, article4, article5);
+                articles.forEach(articleDao::save);
+                req.setPathInfo("/1/anyString");
+
+                //when & then
+                assertThrows(HttpBadRequestException.class, () -> {
+                    servlet.doPost(req, res);
+                });
+            }
+
+            @Test
+            @DisplayName("pathInfo가 숫자가 아닌 string으로 들어온 경우")
+            void pathInfoWithStringId() throws Exception {
+                //given
+                req.setPathInfo("/helloworld");
+
+                //when & then
+                assertThrows(HttpBadRequestException.class, () -> {
+                    servlet.doPost(req, res);
+                });
+            }
+        }
+
+        @Nested
+        @DisplayName("_method가 PUT인 경우")
+        class MethodPut{
+            @Test
+            @DisplayName("작성자가 article을 수정한 경우, 수정된 article이 잘 저장된다.")
+            void methodPut() throws Exception {
+                //given
+                Member member = new Member(1l,"id1","pw1","nick1","email1");
+                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                String updateTitle = "updatedTitle";
+                String updateContents = "updatedContents";
+                articleDao.save(article);
+                MockSession session = new MockSession();
+                session.setAttribute("member",member);
+                MockRequest req = new MockRequest();
+                MockResponse res = new MockResponse();
+                req.setSession(session);
+                req.setPathInfo("/"+article.getId());
+
+                req.setParameter("_method","PUT");
+                req.setParameter("title",updateTitle);
+                req.setParameter("contents",updateContents);
+
+                //when
+                servlet.doPost(req,res);
+
+                //then
+                Optional<Article> byId = articleDao.findById(article.getId());
+                assertTrue(byId.isPresent());
+                Article updated = byId.get();
+                assertEquals(article.getId(),updated.getId());
+                assertEquals(article.getWriter(),updated.getWriter());
+                assertEquals(updateTitle,updated.getTitle());
+                assertEquals(updateContents,updated.getContents());
+                assertEquals("/questions/"+updated.getId(),res.getRedirection());
+            }
+
+            @Test
+            @DisplayName("작성자가 아닌 사람이 article을 수정한 경우, bad request가 반환된다..")
+            void methodPutWithOtherWriter() throws Exception {
+                //given
+                Member member = new Member(1l,"id1","pw1","nick1","email1");
+                Member member2 = new Member(2l,"id2","pw2","nick2","email2");
+                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                String updateTitle = "updatedTitle";
+                String updateContents = "updatedContents";
+                articleDao.save(article);
+                MockSession session = new MockSession();
+                session.setAttribute("member",member2);
+                MockRequest req = new MockRequest();
+                MockResponse res = new MockResponse();
+                req.setSession(session);
+                req.setPathInfo("/"+article.getId());
+
+                req.setParameter("_method","PUT");
+                req.setParameter("title",updateTitle);
+                req.setParameter("contents",updateContents);
+
+                //when & then
+                assertThrows(HttpBadRequestException.class,()->{
+                    servlet.doPost(req,res);
+                });
+
+                //수정이 되면 안된다.
+                Optional<Article> byId = articleDao.findById(article.getId());
+                assertTrue(byId.isPresent());
+                Article notUpdated = byId.get();
+                assertEquals(article.getId(),notUpdated.getId());
+                assertEquals(article.getWriter(),notUpdated.getWriter());
+                assertEquals(article.getTitle(),notUpdated.getTitle());
+                assertEquals(article.getContents(),notUpdated.getContents());
+            }
+
+            @Test
+            @DisplayName("작성자 Null값의 title로 업데이트 한 경우, bad request가 반환된다..")
+            void methodPutWithNullTitle() throws Exception {
+                //given
+                Member member = new Member(1l,"id1","pw1","nick1","email1");
+                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                String updateTitle = null;
+                String updateContents = "updatedContents";
+                articleDao.save(article);
+                MockSession session = new MockSession();
+                session.setAttribute("member",member);
+                MockRequest req = new MockRequest();
+                MockResponse res = new MockResponse();
+                req.setSession(session);
+                req.setPathInfo("/"+article.getId());
+
+                req.setParameter("_method","PUT");
+                req.setParameter("title",updateTitle);
+                req.setParameter("contents",updateContents);
+
+                //when & then
+                assertThrows(HttpBadRequestException.class,()->{
+                    servlet.doPost(req,res);
+                });
+
+                //수정이 되면 안된다.
+                Optional<Article> byId = articleDao.findById(article.getId());
+                assertTrue(byId.isPresent());
+                Article notUpdated = byId.get();
+                assertEquals(article.getId(),notUpdated.getId());
+                assertEquals(article.getWriter(),notUpdated.getWriter());
+                assertEquals(article.getTitle(),notUpdated.getTitle());
+                assertEquals(article.getContents(),notUpdated.getContents());
+            }
+
+            @Test
+            @DisplayName("작성자 blank값의 title로 업데이트 한 경우, bad request가 반환된다..")
+            void methodPutWithBlankTitle() throws Exception {
+                //given
+                Member member = new Member(1l,"id1","pw1","nick1","email1");
+                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                String updateTitle = "    ";
+                String updateContents = "updatedContents";
+                articleDao.save(article);
+                MockSession session = new MockSession();
+                session.setAttribute("member",member);
+                MockRequest req = new MockRequest();
+                MockResponse res = new MockResponse();
+                req.setSession(session);
+                req.setPathInfo("/"+article.getId());
+
+                req.setParameter("_method","PUT");
+                req.setParameter("title",updateTitle);
+                req.setParameter("contents",updateContents);
+
+                //when & then
+                assertThrows(HttpBadRequestException.class,()->{
+                    servlet.doPost(req,res);
+                });
+
+                //수정이 되면 안된다.
+                Optional<Article> byId = articleDao.findById(article.getId());
+                assertTrue(byId.isPresent());
+                Article notUpdated = byId.get();
+                assertEquals(article.getId(),notUpdated.getId());
+                assertEquals(article.getWriter(),notUpdated.getWriter());
+                assertEquals(article.getTitle(),notUpdated.getTitle());
+                assertEquals(article.getContents(),notUpdated.getContents());
+            }
+
+            @Test
+            @DisplayName("작성자 Null값의 contents로 업데이트 한 경우, bad request가 반환된다..")
+            void methodPutWithNullContents() throws Exception {
+                //given
+                Member member = new Member(1l,"id1","pw1","nick1","email1");
+                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                String updateTitle = "updatedTitle";
+                String updateContents = null;
+                articleDao.save(article);
+                MockSession session = new MockSession();
+                session.setAttribute("member",member);
+                MockRequest req = new MockRequest();
+                MockResponse res = new MockResponse();
+                req.setSession(session);
+                req.setPathInfo("/"+article.getId());
+
+                req.setParameter("_method","PUT");
+                req.setParameter("title",updateTitle);
+                req.setParameter("contents",updateContents);
+
+                //when & then
+                assertThrows(HttpBadRequestException.class,()->{
+                    servlet.doPost(req,res);
+                });
+
+                //수정이 되면 안된다.
+                Optional<Article> byId = articleDao.findById(article.getId());
+                assertTrue(byId.isPresent());
+                Article notUpdated = byId.get();
+                assertEquals(article.getId(),notUpdated.getId());
+                assertEquals(article.getWriter(),notUpdated.getWriter());
+                assertEquals(article.getTitle(),notUpdated.getTitle());
+                assertEquals(article.getContents(),notUpdated.getContents());
+            }
+
+            @Test
+            @DisplayName("작성자 blank값의 contents로 업데이트 한 경우, bad request가 반환된다..")
+            void methodPutWithBlankContents() throws Exception {
+                //given
+                Member member = new Member(1l,"id1","pw1","nick1","email1");
+                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                String updateTitle = "updatedTitle";
+                String updateContents = "    ";
+                articleDao.save(article);
+                MockSession session = new MockSession();
+                session.setAttribute("member",member);
+                MockRequest req = new MockRequest();
+                MockResponse res = new MockResponse();
+                req.setSession(session);
+                req.setPathInfo("/"+article.getId());
+
+                req.setParameter("_method","PUT");
+                req.setParameter("title",updateTitle);
+                req.setParameter("contents",updateContents);
+
+                //when & then
+                assertThrows(HttpBadRequestException.class,()->{
+                    servlet.doPost(req,res);
+                });
+
+                //수정이 되면 안된다.
+                Optional<Article> byId = articleDao.findById(article.getId());
+                assertTrue(byId.isPresent());
+                Article notUpdated = byId.get();
+                assertEquals(article.getId(),notUpdated.getId());
+                assertEquals(article.getWriter(),notUpdated.getWriter());
+                assertEquals(article.getTitle(),notUpdated.getTitle());
+                assertEquals(article.getContents(),notUpdated.getContents());
+            }
+        }
+    }
 
     private class MockRequest extends BaseHttpServletRequest {
         private Map<String, Object> attributes = new HashMap<>();
         private String forwardPath;
         private String pathInfo;
         private Map<String, String> parameters = new HashMap<>();
+        private MockSession session;
+
+        public void setSession(MockSession session){
+            this.session = session;
+        }
+        @Override
+        public HttpSession getSession() {
+            return session;
+        }
+
+        @Override
+        public HttpSession getSession(boolean b) {
+            return session;
+        }
 
         public void setPathInfo(String pathInfo) {
             this.pathInfo = pathInfo;

--- a/src/test/java/com/hyeonuk/jspcafe/global/db/DBConnectionInfoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/global/db/DBConnectionInfoTest.java
@@ -1,0 +1,165 @@
+package com.hyeonuk.jspcafe.global.db;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("DBConnectionInfo 클래스")
+class DBConnectionInfoTest {
+    private DBConnectionInfo dbConnectionInfo;
+
+    @Nested
+    @DisplayName("기본 생성자는")
+    class DefaultConstructorTest{
+        @Test
+        @DisplayName("username, password, driverClassName, url을 입력받으면 값을 저장할 수 있다.")
+        void defaultConstructorTest(){
+            //given
+            String url = "jdbc:mysql://localhost:3306/test";
+            String username = "username";
+            String password = "password";
+            String driverClassName = "com.mysql.cj.jdbc.Driver";
+
+            //when
+            dbConnectionInfo = new DBConnectionInfo(url,username,password,driverClassName);
+
+            //then
+            assertAll("default constructor",
+                    ()->assertEquals(url,dbConnectionInfo.getUrl()),
+                    ()->assertEquals(username,dbConnectionInfo.getUsername()),
+                    ()->assertEquals(password,dbConnectionInfo.getPassword()),
+                    ()->assertEquals(driverClassName,dbConnectionInfo.getDriverClassName()));
+        }
+
+        @Test
+        @DisplayName("url null이면 오류를 던진다.")
+        void urlNullTest(){
+            //given
+            String url = null;
+            String username = "username";
+            String password = "password";
+            String driverClassName = "com.mysql.cj.jdbc.Driver";
+
+            //when
+            assertThrows(IllegalArgumentException.class,()->{
+                dbConnectionInfo = new DBConnectionInfo(url,username,password,driverClassName);
+            });
+        }
+
+        @Test
+        @DisplayName("username이 null이면 오류를 던진다.")
+        void usernameNullTest(){
+            //given
+            String url = "jdbc:mysql://localhost:3306/test";
+            String username = null;
+            String password = "password";
+            String driverClassName = "com.mysql.cj.jdbc.Driver";
+
+            //when
+            assertThrows(IllegalArgumentException.class,()->{
+                dbConnectionInfo = new DBConnectionInfo(url,username,password,driverClassName);
+            });
+        }
+
+        @Test
+        @DisplayName("password가 null이면 오류를 던진다.")
+        void passwordNullTest(){
+            //given
+            String url = "jdbc:mysql://localhost:3306/test";
+            String username = "username";
+            String password = null;
+            String driverClassName = "com.mysql.cj.jdbc.Driver";
+
+            //when
+            assertThrows(IllegalArgumentException.class,()->{
+                dbConnectionInfo = new DBConnectionInfo(url,username,password,driverClassName);
+            });
+        }
+
+        @Test
+        @DisplayName("driverClassName이 null이면 오류를 던진다.")
+        void driverClassNameNullTest(){
+            //given
+            String url = "jdbc:mysql://localhost:3306/test";
+            String username = "username";
+            String password = "password";
+            String driverClassName = null;
+
+            //when
+            assertThrows(IllegalArgumentException.class,()->{
+                dbConnectionInfo = new DBConnectionInfo(url,username,password,driverClassName);
+            });
+        }
+    }
+
+    @Nested
+    @DisplayName("yaml파일의 경로를 받는 생성자는")
+    class YamlConstructorTest{
+        @DisplayName("yaml파일에 모든 값이 존재하면 생성되어야한다.")
+        @Test
+        void yamlConstructorTest(){
+            //given
+            String yamlPath = "yaml/db/all.yml";
+
+            //when
+            dbConnectionInfo = new DBConnectionInfo(yamlPath);
+
+            //then
+            assertAll("default constructor",
+                    ()->assertEquals("url",dbConnectionInfo.getUrl()),
+                    ()->assertEquals("username",dbConnectionInfo.getUsername()),
+                    ()->assertEquals("password",dbConnectionInfo.getPassword()),
+                    ()->assertEquals("driverClassName",dbConnectionInfo.getDriverClassName()));
+        }
+
+        @Test
+        @DisplayName("url null이면 오류를 던진다.")
+        void urlNullTest(){
+            //given
+            String yamlPath = "yaml/db/urlNull.yml";
+
+            //when
+            assertThrows(IllegalArgumentException.class,()->{
+                dbConnectionInfo = new DBConnectionInfo(yamlPath);
+            });
+        }
+
+        @Test
+        @DisplayName("username이 null이면 오류를 던진다.")
+        void usernameNullTest(){
+            //given
+            String yamlPath = "yaml/db/usernameNull.yml";
+
+            //when
+            assertThrows(IllegalArgumentException.class,()->{
+                dbConnectionInfo = new DBConnectionInfo(yamlPath);
+            });
+        }
+
+        @Test
+        @DisplayName("password가 null이면 오류를 던진다.")
+        void passwordNullTest(){
+            //given
+            String yamlPath = "yaml/db/passwordNull.yml";
+
+            //when
+            assertThrows(IllegalArgumentException.class,()->{
+                dbConnectionInfo = new DBConnectionInfo(yamlPath);
+            });
+        }
+
+        @Test
+        @DisplayName("driverClassName이 null이면 오류를 던진다.")
+        void driverClassNameNullTest(){
+            //given
+            String yamlPath = "yaml/db/driverClassNameNull.yml";
+
+            //when
+            assertThrows(IllegalArgumentException.class,()->{
+                dbConnectionInfo = new DBConnectionInfo(yamlPath);
+            });
+        }
+    }
+}

--- a/src/test/java/com/hyeonuk/jspcafe/member/dao/MysqlMemberDaoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/member/dao/MysqlMemberDaoTest.java
@@ -1,7 +1,7 @@
 package com.hyeonuk.jspcafe.member.dao;
 
 import com.hyeonuk.jspcafe.global.db.DBConnectionInfo;
-import com.hyeonuk.jspcafe.global.db.mysql.DBManager;
+import com.hyeonuk.jspcafe.global.db.DBManagerIml;
 import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
 import com.hyeonuk.jspcafe.member.domain.Member;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,12 +17,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("MemberDao 테스트")
 class MysqlMemberDaoTest {
-    DBManager manager;
+    DBManagerIml manager;
     MemberDao memberDao;
     @BeforeEach
     void setUp() throws SQLException, ClassNotFoundException {
         DBConnectionInfo connectionInfo = new DBConnectionInfo("application-testdb.yml");
-        manager = new DBManager(connectionInfo);
+        manager = new DBManagerIml(connectionInfo);
         memberDao = new MysqlMemberDao(manager);
     }
 

--- a/src/test/java/com/hyeonuk/jspcafe/member/dao/MysqlMemberDaoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/member/dao/MysqlMemberDaoTest.java
@@ -1,6 +1,7 @@
 package com.hyeonuk.jspcafe.member.dao;
 
-import com.hyeonuk.jspcafe.global.db.mysql.MysqlManager;
+import com.hyeonuk.jspcafe.global.db.DBConnectionInfo;
+import com.hyeonuk.jspcafe.global.db.mysql.DBManager;
 import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
 import com.hyeonuk.jspcafe.member.domain.Member;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,11 +17,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("MemberDao 테스트")
 class MysqlMemberDaoTest {
-    MysqlManager manager;
+    DBManager manager;
     MemberDao memberDao;
     @BeforeEach
     void setUp() throws SQLException, ClassNotFoundException {
-        manager = new MysqlManager();
+        DBConnectionInfo connectionInfo = new DBConnectionInfo("application-testdb.yml");
+        manager = new DBManager(connectionInfo);
         memberDao = new MysqlMemberDao(manager);
     }
 

--- a/src/test/resources/application-testdb.yml
+++ b/src/test/resources/application-testdb.yml
@@ -1,0 +1,6 @@
+db:
+  datasource:
+    username: root
+    password: " "
+    url: jdbc:h2:mem:cafe;MODE=MYSQL;DATABASE_TO_LOWER=TRUE;NON_KEYWORDS=USER;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;
+    driver-class-name: org.h2.Driver

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -1,0 +1,20 @@
+-- 기존 테이블이 존재한다면 삭제
+DROP TABLE IF EXISTS ARTICLE;
+DROP TABLE IF EXISTS MEMBER;
+
+-- member 테이블 생성
+CREATE TABLE MEMBER (
+                        id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                        memberId VARCHAR(255) UNIQUE NOT NULL,
+                        password VARCHAR(255) NOT NULL,
+                        nickname VARCHAR(255) NOT NULL,
+                        email VARCHAR(255) NOT NULL
+);
+
+-- article 테이블 생성
+CREATE TABLE ARTICLE (
+                         id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                         title VARCHAR(255) NOT NULL,
+                         writer VARCHAR(255) NOT NULL,
+                         contents TEXT NOT NULL
+);

--- a/src/test/resources/yaml/db/all.yml
+++ b/src/test/resources/yaml/db/all.yml
@@ -1,0 +1,6 @@
+db:
+  datasource:
+    username: username
+    password: password
+    url: url
+    driver-class-name: driverClassName

--- a/src/test/resources/yaml/db/driverClassNameNull.yml
+++ b/src/test/resources/yaml/db/driverClassNameNull.yml
@@ -1,0 +1,5 @@
+db:
+  datasource:
+    username: username
+    password: password
+    url: url

--- a/src/test/resources/yaml/db/passwordNull.yml
+++ b/src/test/resources/yaml/db/passwordNull.yml
@@ -1,0 +1,5 @@
+db:
+  datasource:
+    username: username
+    url: url
+    driver-class-name: driverClassName

--- a/src/test/resources/yaml/db/urlNull.yml
+++ b/src/test/resources/yaml/db/urlNull.yml
@@ -1,0 +1,5 @@
+db:
+  datasource:
+    username: username
+    password: passwordall.yml
+    driver-class-name: driverClassName

--- a/src/test/resources/yaml/db/usernameNull.yml
+++ b/src/test/resources/yaml/db/usernameNull.yml
@@ -1,0 +1,5 @@
+db:
+  datasource:
+    password: password
+    url: url
+    driver-class-name: driverClassName


### PR DESCRIPTION
## 구현 내용
테스트용 DB를 설정하기 위해 DB Manager에서DB Info를 DI 받는 구조로 설계.
- 기존 테스트는 mysql 에 강한 의존을 하고 있어서 테스트 시간이 느렸습니다.
<img width="544" alt="image" src="https://github.com/user-attachments/assets/db59fe98-360b-4380-ac54-d1811e09be46">

- 테스트용 db를 h2로 쉽게 갈아낄 수 있도록 구조를 변경한 뒤, test용 db를 주입해 테스트코드에서 실행했습니다. 덕분에 테스트 수행 속도가 확실히 줄어들었습니다.
<img width="522" alt="image" src="https://github.com/user-attachments/assets/78a52709-6be4-4743-9b42-46005e7af8e2">

- 게시글 권한 부여
 - 기존 SessionFilter의 urlMapping에 게시글과 관련된 url request를 추가

- 게시글 삭제 기능과 업데이트 기능
 - 진행시에 권한 체크하여 작성자가 아니라면 error-page로 돌아갈 수 있도록 구현

- 커버리지
<img width="730" alt="image" src="https://github.com/user-attachments/assets/ed2cbcef-6413-41cb-8491-47b0c38a8d25">

## 고민 사항

## 기타
