### PR TITLE
[김준기] step-6 댓글

### DIFF
--- a/src/main/java/woowa/camp/jspcafe/configuration/AppContextListener.java
+++ b/src/main/java/woowa/camp/jspcafe/configuration/AppContextListener.java
@@ -9,9 +9,11 @@ import org.slf4j.LoggerFactory;
 import woowa.camp.jspcafe.infra.DatabaseConnector;
 import woowa.camp.jspcafe.repository.article.ArticleRepository;
 import woowa.camp.jspcafe.repository.article.DBArticleRepository;
+import woowa.camp.jspcafe.repository.reply.DBReplyRepository;
 import woowa.camp.jspcafe.repository.user.DBUserRepository;
 import woowa.camp.jspcafe.repository.user.UserRepository;
 import woowa.camp.jspcafe.service.ArticleService;
+import woowa.camp.jspcafe.service.ReplyService;
 import woowa.camp.jspcafe.service.UserService;
 import woowa.camp.jspcafe.infra.time.DateTimeProvider;
 import woowa.camp.jspcafe.infra.time.LocalDateTimeProvider;
@@ -30,17 +32,27 @@ public class AppContextListener implements ServletContextListener {
 
         DatabaseConnector connector = new DatabaseConnector(context);
 
+        InMemoryDBInitializer.createUserTable(connector);
+        InMemoryDBInitializer.createArticleTable(connector);
+        InMemoryDBInitializer.createReplyTable(connector);
+
         UserRepository userRepository = new DBUserRepository(connector);
         UserService userService = new UserService(userRepository, dateTimeProvider);
 
         ArticleRepository articleRepository = new DBArticleRepository(connector);
         ArticleService articleService = new ArticleService(articleRepository, userRepository, dateTimeProvider);
 
+        DBReplyRepository replyRepository = new DBReplyRepository(connector);
+        ReplyService replyService = new ReplyService(replyRepository, dateTimeProvider);
+
         context.setAttribute("userRepository", userRepository);
         context.setAttribute("userService", userService);
 
         context.setAttribute("articleRepository", articleRepository);
         context.setAttribute("articleService", articleService);
+
+        context.setAttribute("replyRepository", replyRepository);
+        context.setAttribute("replyService", replyService);
 
         log.debug("AppContextListener - contextInitialized end");
     }

--- a/src/main/java/woowa/camp/jspcafe/configuration/AppContextListener.java
+++ b/src/main/java/woowa/camp/jspcafe/configuration/AppContextListener.java
@@ -40,10 +40,10 @@ public class AppContextListener implements ServletContextListener {
         UserService userService = new UserService(userRepository, dateTimeProvider);
 
         ArticleRepository articleRepository = new DBArticleRepository(connector);
-        ArticleService articleService = new ArticleService(articleRepository, userRepository, dateTimeProvider);
 
         DBReplyRepository replyRepository = new DBReplyRepository(connector);
         ReplyService replyService = new ReplyService(replyRepository, userRepository, dateTimeProvider);
+        ArticleService articleService = new ArticleService(articleRepository, userRepository, replyRepository, dateTimeProvider);
 
         context.setAttribute("userRepository", userRepository);
         context.setAttribute("userService", userService);

--- a/src/main/java/woowa/camp/jspcafe/configuration/AppContextListener.java
+++ b/src/main/java/woowa/camp/jspcafe/configuration/AppContextListener.java
@@ -43,7 +43,7 @@ public class AppContextListener implements ServletContextListener {
         ArticleService articleService = new ArticleService(articleRepository, userRepository, dateTimeProvider);
 
         DBReplyRepository replyRepository = new DBReplyRepository(connector);
-        ReplyService replyService = new ReplyService(replyRepository, dateTimeProvider);
+        ReplyService replyService = new ReplyService(replyRepository, userRepository, dateTimeProvider);
 
         context.setAttribute("userRepository", userRepository);
         context.setAttribute("userService", userService);

--- a/src/main/java/woowa/camp/jspcafe/configuration/InMemoryDBInitializer.java
+++ b/src/main/java/woowa/camp/jspcafe/configuration/InMemoryDBInitializer.java
@@ -18,7 +18,8 @@ public class InMemoryDBInitializer {
                         content VARCHAR(5000) NOT NULL,
                         hits INT DEFAULT 0,
                         created_at DATE NOT NULL,
-                        updated_at DATE
+                        updated_at DATE,
+                        deleted_at DATE
                     )
                     """;
 

--- a/src/main/java/woowa/camp/jspcafe/configuration/InMemoryDBInitializer.java
+++ b/src/main/java/woowa/camp/jspcafe/configuration/InMemoryDBInitializer.java
@@ -1,0 +1,72 @@
+package woowa.camp.jspcafe.configuration;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import woowa.camp.jspcafe.infra.DatabaseConnector;
+
+public class InMemoryDBInitializer {
+
+    public static void createArticleTable(DatabaseConnector connector) {
+        try (Connection connection = connector.getConnection();
+             Statement statement = connection.createStatement()) {
+
+            String createTableSQL = """
+                    CREATE TABLE IF NOT EXISTS articles (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        author_id BIGINT,
+                        title VARCHAR(255) NOT NULL,
+                        content VARCHAR(5000) NOT NULL,
+                        hits INT DEFAULT 0,
+                        created_at DATE NOT NULL,
+                        updated_at DATE
+                    )
+                    """;
+
+            statement.execute(createTableSQL);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create tables", e);
+        }
+    }
+
+    public static void createUserTable(DatabaseConnector connector) {
+        try (Connection connection = connector.getConnection();
+             Statement statement = connection.createStatement()) {
+
+            String createTableSQL = """
+                    CREATE TABLE IF NOT EXISTS users (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        email VARCHAR(255) NOT NULL,
+                        nickname VARCHAR(255) NOT NULL,
+                        password VARCHAR(255) NOT NULL,
+                        register_at DATE NOT NULL
+                    )
+                    """;
+
+            statement.execute(createTableSQL);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create tables", e);
+        }
+    }
+
+    public static void createReplyTable(DatabaseConnector connector) {
+        try (Connection connection = connector.getConnection();
+             Statement statement = connection.createStatement()) {
+
+            String createTableSQL = """
+                    CREATE TABLE IF NOT EXISTS replies (
+                        reply_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        user_id BIGINT,
+                        article_id BIGINT,
+                        content VARCHAR(255),
+                        created_at DATETIME,
+                        updated_at DATETIME,
+                        deleted_at DATETIME
+                    )
+                    """;
+
+            statement.execute(createTableSQL);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create tables", e);
+        }
+    }
+}

--- a/src/main/java/woowa/camp/jspcafe/domain/Article.java
+++ b/src/main/java/woowa/camp/jspcafe/domain/Article.java
@@ -14,6 +14,7 @@ public class Article {
 
     private LocalDate createdAt;
     private LocalDate updatedAt;
+    private LocalDate deletedAt;
 
     private Article(Long id, Long authorId, String title, String content, Integer hits, LocalDate createdAt,
                     LocalDate updatedAt

--- a/src/main/java/woowa/camp/jspcafe/domain/Reply.java
+++ b/src/main/java/woowa/camp/jspcafe/domain/Reply.java
@@ -1,0 +1,75 @@
+package woowa.camp.jspcafe.domain;
+
+import java.time.LocalDateTime;
+
+public class Reply {
+
+    private Long id;
+    private Long userId;
+    private Long articleId;
+
+    private String content;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private LocalDateTime deletedAt;
+
+    public Reply(Long userId, Long articleId, String content,
+                 LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt
+    ) {
+        this.userId = userId;
+        this.articleId = articleId;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Long getArticleId() {
+        return articleId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+
+    /**
+     * only allowed at repository, test
+     */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "Reply{" +
+                "id=" + id +
+                ", userId=" + userId +
+                ", articleId=" + articleId +
+                ", content='" + content + '\'' +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", deletedAt=" + deletedAt +
+                '}';
+    }
+}

--- a/src/main/java/woowa/camp/jspcafe/domain/Reply.java
+++ b/src/main/java/woowa/camp/jspcafe/domain/Reply.java
@@ -25,6 +25,28 @@ public class Reply {
         this.deletedAt = deletedAt;
     }
 
+    private Reply(Long replyId, Long userId, Long articleId, String content, LocalDateTime createdAt,
+                  LocalDateTime updatedAt, LocalDateTime deletedAt
+    ) {
+        this.replyId = replyId;
+        this.userId = userId;
+        this.articleId = articleId;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
+    }
+
+    public static Reply update(Reply originReply, String content, LocalDateTime updatedAt) {
+        return new Reply(originReply.getReplyId(),
+                originReply.getUserId(),
+                originReply.getArticleId(),
+                content,
+                originReply.getCreatedAt(),
+                updatedAt,
+                originReply.getDeletedAt());
+    }
+
     public Long getReplyId() {
         return replyId;
     }

--- a/src/main/java/woowa/camp/jspcafe/domain/Reply.java
+++ b/src/main/java/woowa/camp/jspcafe/domain/Reply.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 
 public class Reply {
 
-    private Long id;
+    private Long replyId;
     private Long userId;
     private Long articleId;
 
@@ -25,8 +25,8 @@ public class Reply {
         this.deletedAt = deletedAt;
     }
 
-    public Long getId() {
-        return id;
+    public Long getReplyId() {
+        return replyId;
     }
 
     public Long getUserId() {
@@ -56,14 +56,14 @@ public class Reply {
     /**
      * only allowed at repository, test
      */
-    public void setId(Long id) {
-        this.id = id;
+    public void setReplyId(Long replyId) {
+        this.replyId = replyId;
     }
 
     @Override
     public String toString() {
         return "Reply{" +
-                "id=" + id +
+                "id=" + replyId +
                 ", userId=" + userId +
                 ", articleId=" + articleId +
                 ", content='" + content + '\'' +

--- a/src/main/java/woowa/camp/jspcafe/domain/exception/ReplyException.java
+++ b/src/main/java/woowa/camp/jspcafe/domain/exception/ReplyException.java
@@ -1,0 +1,9 @@
+package woowa.camp.jspcafe.domain.exception;
+
+public class ReplyException extends RuntimeException {
+
+    public ReplyException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/woowa/camp/jspcafe/infra/time/DateTimeProvider.java
+++ b/src/main/java/woowa/camp/jspcafe/infra/time/DateTimeProvider.java
@@ -1,9 +1,12 @@
 package woowa.camp.jspcafe.infra.time;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public interface DateTimeProvider {
 
     LocalDate getNow();
+
+    LocalDateTime getNowAsLocalDateTime();
 
 }

--- a/src/main/java/woowa/camp/jspcafe/infra/time/LocalDateTimeProvider.java
+++ b/src/main/java/woowa/camp/jspcafe/infra/time/LocalDateTimeProvider.java
@@ -1,12 +1,18 @@
 package woowa.camp.jspcafe.infra.time;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public class LocalDateTimeProvider implements DateTimeProvider {
 
     @Override
     public LocalDate getNow() {
         return LocalDate.now();
+    }
+
+    @Override
+    public LocalDateTime getNowAsLocalDateTime() {
+        return LocalDateTime.now();
     }
 
 }

--- a/src/main/java/woowa/camp/jspcafe/repository/article/ArticleRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/article/ArticleRepository.java
@@ -1,5 +1,6 @@
 package woowa.camp.jspcafe.repository.article;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import woowa.camp.jspcafe.domain.Article;
@@ -18,6 +19,6 @@ public interface ArticleRepository {
 
     void update(Article article);
 
-    void deleteById(Long id);
+    void softDeleteById(Long id, LocalDate deletedTime);
 
 }

--- a/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
@@ -7,6 +7,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -179,13 +180,14 @@ public class DBArticleRepository implements ArticleRepository {
     }
 
     @Override
-    public void deleteById(Long id) {
-        String sql = "DELETE FROM articles WHERE id = ?";
+    public void softDeleteById(Long id, LocalDate deletedTime) {
+        String sql = "UPDATE articles SET deleted_at = ? WHERE id = ?";
 
         try (Connection connection = connector.getConnection();
-             PreparedStatement pstmt = connection.prepareStatement(sql)) {
-
-            pstmt.setLong(1, id);
+             PreparedStatement pstmt = connection.prepareStatement(sql)
+        ) {
+            pstmt.setDate(1, Date.valueOf(deletedTime));
+            pstmt.setLong(2, id);
 
             int affectedRows = pstmt.executeUpdate();
             if (affectedRows == 0) {

--- a/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
@@ -66,7 +66,7 @@ public class DBArticleRepository implements ArticleRepository {
             return Optional.empty();
         }
 
-        String sql = "SELECT * FROM articles WHERE id = ?";
+        String sql = "SELECT * FROM articles WHERE id = ? AND deleted_at IS NULL";
 
         try (Connection connection = connector.getConnection();
              PreparedStatement pstmt = connection.prepareStatement(sql)) {
@@ -133,7 +133,9 @@ public class DBArticleRepository implements ArticleRepository {
 
     @Override
     public List<Article> findByOffsetPagination(int offset, int limit) {
-        String sql = "SELECT * FROM articles ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?";
+        String sql = "SELECT * FROM articles a "
+                + "WHERE deleted_at IS NULL "
+                + "ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?";
 
         try (Connection connection = connector.getConnection();
              PreparedStatement pstmt = connection.prepareStatement(sql)) {

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/DBReplyRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/DBReplyRepository.java
@@ -1,0 +1,124 @@
+package woowa.camp.jspcafe.repository.reply;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import woowa.camp.jspcafe.domain.Reply;
+import woowa.camp.jspcafe.infra.DatabaseConnector;
+
+public class DBReplyRepository implements ReplyRepository {
+
+    private final DatabaseConnector connector;
+
+    public DBReplyRepository(DatabaseConnector connector) {
+        this.connector = connector;
+    }
+
+    @Override
+    public Reply save(Reply reply) {
+        String sql = "INSERT INTO replies (user_id, article_id, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?)";
+
+        try (Connection connection = connector.getConnection();
+             PreparedStatement pstmt = connection.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS)
+        ) {
+            pstmt.setLong(1, reply.getUserId());
+            pstmt.setLong(2, reply.getArticleId());
+            pstmt.setString(3, reply.getContent());
+            pstmt.setTimestamp(4, Timestamp.valueOf(reply.getCreatedAt()));
+            pstmt.setTimestamp(5, Timestamp.valueOf(reply.getUpdatedAt()));
+
+            int affectedRows = pstmt.executeUpdate();
+
+            if (affectedRows == 0) {
+                throw new SQLException("댓글 저장을 실패했습니다. 영향을 받은 행이 없습니다.");
+            }
+
+            try (ResultSet generatedKeys = pstmt.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    reply.setId(generatedKeys.getLong(1));
+                } else {
+                    throw new SQLException("게시글 저장을 실패했습니다. id를 획득하지 못했습니다.");
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        return reply;
+    }
+
+    @Override
+    public Optional<Reply> findById(Long id) {
+        String sql = "SELECT * FROM replies WHERE id = ? AND deleted_at IS NULL";
+
+        try (Connection conn = connector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)
+        ) {
+            pstmt.setLong(1, id);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(mapRowToReply(rs));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Reply> findByArticleId(Long articleId) {
+        List<Reply> replies = new ArrayList<>();
+        String sql = "SELECT * FROM replies WHERE article_id = ? AND deleted_at IS NULL";
+
+        try (Connection conn = connector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)
+        ) {
+            pstmt.setLong(1, articleId);
+            try (ResultSet rs = pstmt.executeQuery()) {
+                while (rs.next()) {
+                    replies.add(mapRowToReply(rs));
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+        return replies;
+    }
+
+    @Override
+    public void softDeleteByUserId(Long userId, LocalDateTime deletedTime) {
+        String sql = "UPDATE replies SET deleted_at = ? WHERE user_id = ?";
+
+        try (Connection conn = connector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)
+        ) {
+            pstmt.setTimestamp(1, Timestamp.valueOf(deletedTime));
+            pstmt.setLong(2, userId);
+            pstmt.executeUpdate();
+
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Reply mapRowToReply(ResultSet rs) throws SQLException {
+        Reply reply = new Reply(
+                rs.getLong("user_id"),
+                rs.getLong("article_id"),
+                rs.getString("content"),
+                rs.getTimestamp("created_at").toLocalDateTime(),
+                rs.getTimestamp("updated_at").toLocalDateTime(),
+                null
+        );
+        reply.setId(rs.getLong("id"));
+        return reply;
+    }
+}

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/DBReplyRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/DBReplyRepository.java
@@ -127,6 +127,22 @@ public class DBReplyRepository implements ReplyRepository {
     }
 
     @Override
+    public void softDeleteByArticleId(Long articleId, LocalDateTime deletedTime) {
+        String sql = "UPDATE replies SET deleted_at = ? WHERE article_id = ?";
+
+        try (Connection conn = connector.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)
+        ) {
+            pstmt.setTimestamp(1, Timestamp.valueOf(deletedTime));
+            pstmt.setLong(2, articleId);
+            pstmt.executeUpdate();
+
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
     public List<ReplyResponse> findByArticleIdWithUser(Long articleId) {
         List<ReplyResponse> replies = new ArrayList<>();
         String sql = "SELECT r.reply_id, r.content, r.user_id, u.nickname, r.created_at "

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import woowa.camp.jspcafe.domain.Reply;
+import woowa.camp.jspcafe.service.dto.ReplyResponse;
 
 public interface ReplyRepository {
 
@@ -12,6 +13,8 @@ public interface ReplyRepository {
     Optional<Reply> findById(Long id);
 
     List<Reply> findByArticleId(Long articleId);
+
+    List<ReplyResponse> findByArticleIdWithUser(Long articleId);
 
     void softDeleteByUserId(Long userId, LocalDateTime deletedTime);
 

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
@@ -1,0 +1,18 @@
+package woowa.camp.jspcafe.repository.reply;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import woowa.camp.jspcafe.domain.Reply;
+
+public interface ReplyRepository {
+
+    Reply save(Reply reply);
+
+    Optional<Reply> findById(Long id);
+
+    List<Reply> findByArticleId(Long articleId);
+
+    void softDeleteByUserId(Long userId, LocalDateTime deletedTime);
+
+}

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
@@ -20,6 +20,8 @@ public interface ReplyRepository {
 
     void softDeleteById(Long id, LocalDateTime deletedTime);
 
+    void softDeleteByArticleId(Long articleId, LocalDateTime deletedTime);
+
     void update(Reply reply);
 
 }

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
@@ -18,4 +18,8 @@ public interface ReplyRepository {
 
     void softDeleteByUserId(Long userId, LocalDateTime deletedTime);
 
+    void softDeleteById(Long id, LocalDateTime deletedTime);
+
+    void update(Reply reply);
+
 }

--- a/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
@@ -1,34 +1,40 @@
 package woowa.camp.jspcafe.service;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import woowa.camp.jspcafe.domain.Article;
+import woowa.camp.jspcafe.domain.Reply;
 import woowa.camp.jspcafe.domain.User;
 import woowa.camp.jspcafe.domain.exception.ArticleException;
 import woowa.camp.jspcafe.domain.exception.UnAuthorizationException;
 import woowa.camp.jspcafe.domain.exception.UserException;
+import woowa.camp.jspcafe.infra.time.DateTimeProvider;
 import woowa.camp.jspcafe.repository.article.ArticleRepository;
 import woowa.camp.jspcafe.repository.dto.ArticleUpdateRequest;
+import woowa.camp.jspcafe.repository.reply.ReplyRepository;
 import woowa.camp.jspcafe.repository.user.UserRepository;
 import woowa.camp.jspcafe.service.dto.ArticleDetailsResponse;
 import woowa.camp.jspcafe.service.dto.ArticlePreviewResponse;
 import woowa.camp.jspcafe.service.dto.ArticleUpdateResponse;
 import woowa.camp.jspcafe.service.dto.ArticleWriteRequest;
-import woowa.camp.jspcafe.infra.time.DateTimeProvider;
 
 public class ArticleService {
 
     private static final Logger log = LoggerFactory.getLogger(ArticleService.class);
     private final ArticleRepository articleRepository;
     private final UserRepository userRepository;
+    private final ReplyRepository replyRepository;
     private final DateTimeProvider dateTimeProvider;
 
     public ArticleService(ArticleRepository articleRepository, UserRepository userRepository,
-                          DateTimeProvider dateTimeProvider) {
+                          ReplyRepository replyRepository, DateTimeProvider dateTimeProvider
+    ) {
         this.articleRepository = articleRepository;
         this.userRepository = userRepository;
+        this.replyRepository = replyRepository;
         this.dateTimeProvider = dateTimeProvider;
     }
 
@@ -78,7 +84,8 @@ public class ArticleService {
 
     private void upHits(Article article) {
         article.upHits();
-        Article updateArticle = Article.update(article, article.getTitle(), article.getContent(), article.getUpdatedAt());
+        Article updateArticle = Article.update(article, article.getTitle(), article.getContent(),
+                article.getUpdatedAt());
         articleRepository.update(updateArticle);
     }
 
@@ -99,12 +106,26 @@ public class ArticleService {
         articleRepository.update(updateArticle);
     }
 
+    /*
+     * 요구사항
+     * - 댓글이 없는 경우 삭제가 가능하다.
+     * - 게시글에 다른 사람이 댓글을 작성한 경우, 게시글 삭제가 불가능하다.
+     * - 자기 자신만 댓글을 작성한 경우만, 게시글 삭제가 가능하다.
+     * - 이 때 게시글을 삭제할 경우 자기가 쓴 댓글도 모두 삭제된다.
+     */
     public void deleteArticle(User user, Long articleId) {
         Article article = findArticle(articleId);
         User author = findAuthor(article.getAuthorId());
         validateEditable(user, author);
 
         articleRepository.deleteById(articleId);
+    }
+
+    // FIXME: 대규모 데이터 고려 필요
+    private boolean isExistNotAuthorReply(Article article) {
+        List<Reply> replies = replyRepository.findByArticleId(article.getId());
+        return replies.stream()
+                .anyMatch(reply -> !reply.getUserId().equals(article.getAuthorId()));
     }
 
     private void validateEditable(User user, User author) {

--- a/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
@@ -118,7 +118,13 @@ public class ArticleService {
         User author = findAuthor(article.getAuthorId());
         validateEditable(user, author);
 
-        articleRepository.deleteById(articleId);
+        if (isExistNotAuthorReply(article)) {
+            throw new ArticleException("다른 사람의 댓글이 있는 게시글은 삭제할 수 없습니다.");
+        }
+
+        LocalDate deletedTime = dateTimeProvider.getNow();
+        articleRepository.softDeleteById(articleId, deletedTime);
+        replyRepository.softDeleteByArticleId(articleId, deletedTime.atStartOfDay());
     }
 
     // FIXME: 대규모 데이터 고려 필요

--- a/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
@@ -5,16 +5,19 @@ import java.util.List;
 import woowa.camp.jspcafe.domain.Reply;
 import woowa.camp.jspcafe.infra.time.DateTimeProvider;
 import woowa.camp.jspcafe.repository.reply.ReplyRepository;
-import woowa.camp.jspcafe.service.dto.ReplyWriteRequest;
+import woowa.camp.jspcafe.repository.user.UserRepository;
 import woowa.camp.jspcafe.service.dto.ReplyResponse;
 
 public class ReplyService {
 
     private final ReplyRepository replyRepository;
+    private final UserRepository userRepository;
     private final DateTimeProvider dateTimeProvider;
 
-    public ReplyService(ReplyRepository replyRepository, DateTimeProvider dateTimeProvider) {
+    public ReplyService(ReplyRepository replyRepository, UserRepository userRepository,
+                        DateTimeProvider dateTimeProvider) {
         this.replyRepository = replyRepository;
+        this.userRepository = userRepository;
         this.dateTimeProvider = dateTimeProvider;
     }
 

--- a/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
@@ -2,11 +2,18 @@ package woowa.camp.jspcafe.service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import woowa.camp.jspcafe.domain.Reply;
+import woowa.camp.jspcafe.domain.User;
+import woowa.camp.jspcafe.domain.exception.ArticleException;
+import woowa.camp.jspcafe.domain.exception.ReplyException;
+import woowa.camp.jspcafe.domain.exception.UnAuthorizationException;
+import woowa.camp.jspcafe.domain.exception.UserException;
 import woowa.camp.jspcafe.infra.time.DateTimeProvider;
 import woowa.camp.jspcafe.repository.reply.ReplyRepository;
 import woowa.camp.jspcafe.repository.user.UserRepository;
 import woowa.camp.jspcafe.service.dto.ReplyResponse;
+import woowa.camp.jspcafe.service.dto.ReplyWriteRequest;
 
 public class ReplyService {
 
@@ -36,6 +43,52 @@ public class ReplyService {
 
     public List<ReplyResponse> findReplyList(Long articleId) {
         return replyRepository.findByArticleIdWithUser(articleId);
+    }
+
+    public void deleteReply(User user, Long articleId, Long replyId) {
+        Reply reply = findReply(replyId);
+        User replier = findReplier(reply.getUserId());
+
+        validateAuthorization(user, replier);
+        validateSameArticle(articleId, reply);
+
+        replyRepository.softDeleteById(reply.getReplyId(), dateTimeProvider.getNowAsLocalDateTime());
+    }
+
+//    // TODO
+//    public void updateReply(User user, ReplyUpdateRequest replyUpdateRequest) {
+//        Reply reply = findReply(replyUpdateRequest.replyId());
+//        User replier = findReplier(user.getId());
+//
+//        validateAuthorization(user, replier);
+//        validateSameArticle(replyUpdateRequest.articleId(), reply);
+//
+//        Reply updateReply = Reply.update(reply, replyUpdateRequest.content(), dateTimeProvider.getNowAsLocalDateTime());
+//        replyRepository.update(updateReply);
+//    }
+
+    private Reply findReply(Long replyId) {
+        return replyRepository.findById(replyId)
+                .orElseThrow(() -> new ReplyException("Reply not found : " + replyId));
+    }
+
+    private User findReplier(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException("User with id " + userId + " not found"));
+    }
+
+    private void validateAuthorization(User user, User replier) {
+        String userEmail = user.getEmail();
+        String authorEmail = replier.getEmail();
+        if (!userEmail.equals(authorEmail)) {
+            throw new UnAuthorizationException("게시글 수정은 작성자의 이메일과 동일해야 합니다. %s, %s".formatted(userEmail, authorEmail));
+        }
+    }
+
+    private void validateSameArticle(Long articleId, Reply reply) {
+        if (!Objects.equals(reply.getArticleId(), articleId)) {
+            throw new ArticleException("편집하려는 댓글의 게시글 id와 일치하지 않습니다. %s %s".formatted(articleId, reply.getArticleId()));
+        }
     }
 
 }

--- a/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
@@ -1,0 +1,38 @@
+package woowa.camp.jspcafe.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import woowa.camp.jspcafe.domain.Reply;
+import woowa.camp.jspcafe.infra.time.DateTimeProvider;
+import woowa.camp.jspcafe.repository.reply.ReplyRepository;
+import woowa.camp.jspcafe.service.dto.ReplyWriteRequest;
+import woowa.camp.jspcafe.service.dto.ReplyResponse;
+
+public class ReplyService {
+
+    private final ReplyRepository replyRepository;
+    private final DateTimeProvider dateTimeProvider;
+
+    public ReplyService(ReplyRepository replyRepository, DateTimeProvider dateTimeProvider) {
+        this.replyRepository = replyRepository;
+        this.dateTimeProvider = dateTimeProvider;
+    }
+
+    public Reply writeReply(ReplyWriteRequest replyWriteRequest) {
+        LocalDateTime currentTime = dateTimeProvider.getNowAsLocalDateTime();
+
+        Reply reply = new Reply(replyWriteRequest.userId(),
+                replyWriteRequest.articleId(),
+                replyWriteRequest.content(),
+                currentTime,
+                currentTime,
+                null);
+
+        return replyRepository.save(reply);
+    }
+
+    public List<ReplyResponse> findReplyList(Long articleId) {
+        return replyRepository.findByArticleIdWithUser(articleId);
+    }
+
+}

--- a/src/main/java/woowa/camp/jspcafe/service/UserService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
                 .orElseThrow(() -> new UserException("User with id " + id + " not found"));
     }
 
-    public void updateUserInfo(Long userId, String password, UserUpdateRequest userUpdateRequest) {
+    public void updateUserProfile(Long userId, String password, UserUpdateRequest userUpdateRequest) {
         User user = findById(userId);
 
         if (!user.getPassword().equals(password)) {
@@ -61,7 +61,7 @@ public class UserService {
         userRepository.update(user, userUpdateRequest);
     }
 
-    public User authenticateUser(String email, String password) {
+    public User login(String email, String password) {
         User user = findByEmail(email);
         if (user.isCorrectUser(email, password)) {
             return user;

--- a/src/main/java/woowa/camp/jspcafe/service/dto/ReplyResponse.java
+++ b/src/main/java/woowa/camp/jspcafe/service/dto/ReplyResponse.java
@@ -22,15 +22,6 @@ public class ReplyResponse {
         this.createdAt = createdAt;
     }
 
-    public static ReplyResponse of(Reply reply, User replier) {
-        return new ReplyResponse(
-                reply.getReplyId(),
-                reply.getContent(),
-                reply.getUserId(),
-                replier.getNickname(),
-                reply.getCreatedAt());
-    }
-
     public Long getReplyId() {
         return replyId;
     }

--- a/src/main/java/woowa/camp/jspcafe/service/dto/ReplyResponse.java
+++ b/src/main/java/woowa/camp/jspcafe/service/dto/ReplyResponse.java
@@ -1,0 +1,64 @@
+package woowa.camp.jspcafe.service.dto;
+
+import java.time.LocalDateTime;
+import woowa.camp.jspcafe.domain.Reply;
+import woowa.camp.jspcafe.domain.User;
+
+public class ReplyResponse {
+
+    private Long replyId;
+    private String content;
+
+    private Long userId;
+    private String userNickname;
+
+    private LocalDateTime createdAt;
+
+    public ReplyResponse(Long replyId, String content, Long userId, String userNickname, LocalDateTime createdAt) {
+        this.replyId = replyId;
+        this.content = content;
+        this.userId = userId;
+        this.userNickname = userNickname;
+        this.createdAt = createdAt;
+    }
+
+    public static ReplyResponse of(Reply reply, User replier) {
+        return new ReplyResponse(
+                reply.getReplyId(),
+                reply.getContent(),
+                reply.getUserId(),
+                replier.getNickname(),
+                reply.getCreatedAt());
+    }
+
+    public Long getReplyId() {
+        return replyId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getUserNickname() {
+        return userNickname;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    @Override
+    public String toString() {
+        return "ReplyResponse{" +
+                "replyId=" + replyId +
+                ", content='" + content + '\'' +
+                ", userId=" + userId +
+                ", userNickname='" + userNickname + '\'' +
+                ", createdAt=" + createdAt +
+                '}';
+    }
+}

--- a/src/main/java/woowa/camp/jspcafe/service/dto/ReplyWriteRequest.java
+++ b/src/main/java/woowa/camp/jspcafe/service/dto/ReplyWriteRequest.java
@@ -1,0 +1,4 @@
+package woowa.camp.jspcafe.service.dto;
+
+public record ReplyWriteRequest(Long userId, Long articleId, String content) {
+}

--- a/src/main/java/woowa/camp/jspcafe/web/filter/AuthenticationFilter.java
+++ b/src/main/java/woowa/camp/jspcafe/web/filter/AuthenticationFilter.java
@@ -41,11 +41,10 @@ public class AuthenticationFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
         if (isUnAuthenticateAPI(httpRequest)) {
-            log.info("비인증 API입니다 - {}", httpRequest.getRequestURI());
             chain.doFilter(request, response);
             return;
         }
-        log.info("인증 API입니다 - {}", httpRequest.getRequestURI());
+
         try {
             Cookie[] cookies = ((HttpServletRequest) request).getCookies();
             validateCookieExist(cookies);

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
@@ -1,0 +1,54 @@
+package woowa.camp.jspcafe.web.servlet.reply;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import woowa.camp.jspcafe.domain.Reply;
+import woowa.camp.jspcafe.domain.User;
+import woowa.camp.jspcafe.service.ReplyService;
+import woowa.camp.jspcafe.service.dto.ReplyWriteRequest;
+
+@WebServlet(name = "replyServlet", value = "/comments/*")
+public class ReplyServlet extends HttpServlet {
+
+    private static final Logger log = LoggerFactory.getLogger(ReplyServlet.class);
+    private ReplyService replyService;
+
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        ServletContext context = config.getServletContext();
+        this.replyService = (ReplyService) context.getAttribute("replyService");
+        if (this.replyService == null) {
+            String errorMessage = "[ServletException] ReplyServlet -> ReplyService not initialized";
+            log.error(errorMessage);
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        log.debug("ReplyServlet doPost start");
+        HttpSession session = req.getSession();
+        User sessionUser = (User) session.getAttribute("WOOWA_SESSIONID");
+
+        Long articleId = Long.parseLong(req.getParameter("articleId"));
+        String content = req.getParameter("content");
+
+        log.info("sessionUser: " + sessionUser + ", articleId: " + articleId + ", content: " + content);
+
+        ReplyWriteRequest replyWriteRequest = new ReplyWriteRequest(sessionUser.getId(), articleId, content);
+        Reply reply = replyService.writeReply(replyWriteRequest);
+
+        log.info("댓글 작성 성공 = {}", reply);
+
+        resp.sendRedirect(req.getContextPath() + "/articles/" + articleId);
+        log.debug("ReplyServlet doPost end");
+    }
+}

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
@@ -13,6 +13,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import woowa.camp.jspcafe.domain.Reply;
 import woowa.camp.jspcafe.domain.User;
+import woowa.camp.jspcafe.domain.exception.ReplyException;
+import woowa.camp.jspcafe.domain.exception.UnAuthorizationException;
 import woowa.camp.jspcafe.service.ReplyService;
 import woowa.camp.jspcafe.service.dto.ReplyWriteRequest;
 
@@ -34,21 +36,70 @@ public class ReplyServlet extends HttpServlet {
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("ReplyServlet doPost start");
+        try {
+            log.debug("ReplyServlet doPost start");
+            String method = req.getParameter("_method");
+
+            if ("DELETE".equalsIgnoreCase(method)) {
+                doDelete(req, resp);
+                return;
+            }
+
+            HttpSession session = req.getSession();
+            User sessionUser = (User) session.getAttribute("WOOWA_SESSIONID");
+
+            Long articleId = Long.parseLong(req.getParameter("articleId"));
+            String content = req.getParameter("content");
+
+            log.info("sessionUser: " + sessionUser + ", articleId: " + articleId + ", content: " + content);
+
+            ReplyWriteRequest replyWriteRequest = new ReplyWriteRequest(sessionUser.getId(), articleId, content);
+            Reply reply = replyService.writeReply(replyWriteRequest);
+
+            log.info("댓글 작성 성공 = {}", reply);
+
+            resp.sendRedirect(req.getContextPath() + "/articles/" + articleId);
+            log.debug("ReplyServlet doPost end");
+        } catch (ReplyException e) {
+            log.warn("[ReplyException]", e);
+            resp.sendError(HttpServletResponse.SC_BAD_REQUEST);
+        } catch (UnAuthorizationException e) {
+            log.warn("[UnAuthorizationException]", e);
+            resp.sendRedirect(req.getContextPath() + "/");
+        }
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        log.debug("ReplyServlet doDelete start");
         HttpSession session = req.getSession();
         User sessionUser = (User) session.getAttribute("WOOWA_SESSIONID");
 
         Long articleId = Long.parseLong(req.getParameter("articleId"));
-        String content = req.getParameter("content");
+        Long replyId = Long.parseLong(req.getParameter("replyId"));
 
-        log.info("sessionUser: " + sessionUser + ", articleId: " + articleId + ", content: " + content);
-
-        ReplyWriteRequest replyWriteRequest = new ReplyWriteRequest(sessionUser.getId(), articleId, content);
-        Reply reply = replyService.writeReply(replyWriteRequest);
-
-        log.info("댓글 작성 성공 = {}", reply);
-
+        replyService.deleteReply(sessionUser, articleId, replyId);
         resp.sendRedirect(req.getContextPath() + "/articles/" + articleId);
-        log.debug("ReplyServlet doPost end");
+        log.debug("ReplyServlet doDelete end");
     }
+
+    // TODO
+//    @Override
+//    protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+//            log.debug("ReplyServlet doPut start");
+//            HttpSession session = req.getSession();
+//            User sessionUser = (User) session.getAttribute("WOOWA_SESSIONID");
+//
+//            Long articleId = Long.parseLong(req.getParameter("articleId"));
+//            Long replyId = Long.parseLong(req.getParameter("replyId"));
+//            String content = req.getParameter("content");
+//
+//            log.info("articleId: " + articleId + ", replyId: " + replyId + ", content: " + content);
+//
+//            ReplyUpdateRequest replyUpdateRequest = new ReplyUpdateRequest(articleId, replyId, content);
+//            replyService.updateReply(sessionUser, replyUpdateRequest);
+//
+//            log.debug("ReplyServlet doPut end");
+//    }
+
 }

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserEditServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserEditServlet.java
@@ -82,7 +82,7 @@ public class UserEditServlet extends HttpServlet {
         String newPassword = req.getParameter("newPassword");
         UserUpdateRequest updateRequest = new UserUpdateRequest(newPassword, newNickname);
 
-        userService.updateUserInfo(userId, password, updateRequest);
+        userService.updateUserProfile(userId, password, updateRequest);
         String contextPath = req.getContextPath();
         resp.sendRedirect(contextPath + "/users");
 

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserLoginServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserLoginServlet.java
@@ -55,7 +55,7 @@ public class UserLoginServlet extends HttpServlet {
         String email = req.getParameter("email");
         String password = req.getParameter("password");
         try {
-            User user = userService.authenticateUser(email, password);
+            User user = userService.login(email, password);
             HttpSession session = req.getSession();
             session.setAttribute("WOOWA_SESSIONID", user);
 

--- a/src/main/resources/configuration/datasource.properties
+++ b/src/main/resources/configuration/datasource.properties
@@ -1,4 +1,9 @@
-datasource.url=jdbc:mysql://3.38.185.245:3306/jsp_cafe
-datasource.username=jungi
-datasource.password=1234567
-datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#datasource.url=jdbc:mysql://3.38.185.245:3306/jsp_cafe
+#datasource.username=jungi
+#datasource.password=1234567
+#datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+
+datasource.url=jdbc:h2:mem:db
+datasource.username=sa
+datasource.password=
+datasource.driver-class-name=org.h2.Driver

--- a/src/main/webapp/WEB-INF/views/article/show.jsp
+++ b/src/main/webapp/WEB-INF/views/article/show.jsp
@@ -27,15 +27,20 @@
         <h3>댓글 ${comments.size()}개</h3>
         <c:forEach var="comment" items="${comments}">
             <div class="comment">
-                <p class="comment-author">${comment.author}</p>
+                <p class="comment-author">${comment.userNickname}</p>
                 <p class="comment-content">${comment.content}</p>
-                <span class="time">${article.createdAt}</span>
+<%--                <span class="time">${comment.createdAt}</span>--%>
+                <fmt:parseDate value="${comment.createdAt}"
+                               pattern="yyyy-MM-dd'T'HH:mm" var="parsedDateTime" type="both" />
+                <fmt:formatDate pattern="yyyy.MM.dd HH:mm" value="${ parsedDateTime }" />
 <%--                <p class="comment-date"><fmt:formatDate value="${comment.createdAt}" pattern="YYYY. MM. DD. HH:mm"/></p>--%>
             </div>
         </c:forEach>
     </div>
 
-    <form class="comment-form" action="${pageContext.request.contextPath}/comments/add" method="post">
+    <form class="comment-form" action="${pageContext.request.contextPath}/comments" method="post">
+        <input type="hidden" name="articleId" value="${article.articleId}">
+<%--        <input type="hidden" name="userId" value="${sessionScope.userId}">--%>
         <input type="hidden" name="articleId" value="${article.articleId}">
         <textarea name="content" placeholder="댓글을 입력하세요"></textarea>
         <button type="submit">등록</button>

--- a/src/main/webapp/WEB-INF/views/article/show.jsp
+++ b/src/main/webapp/WEB-INF/views/article/show.jsp
@@ -8,7 +8,7 @@
 
     <div class="article-meta">
         <span>작성자: ${article.authorNickname}</span>
-<%--        <span>작성일자: <fmt:formatDate value="${article.createdAt}" pattern="YYYY. MM. DD. HH:mm"/></span>--%>
+        <%--        <span>작성일자: <fmt:formatDate value="${article.createdAt}" pattern="YYYY. MM. DD. HH:mm"/></span>--%>
         <span class="time">${article.createdAt}</span>
         <span>조회: ${article.hits}</span>
     </div>
@@ -17,7 +17,8 @@
 
     <div class="article-actions">
         <a href="${pageContext.request.contextPath}/articles/edit/${article.articleId}" class="edit-button">수정</a>
-        <form action="${pageContext.request.contextPath}/articles/edit/${article.articleId}" method="post" style="display:inline;">
+        <form action="${pageContext.request.contextPath}/articles/edit/${article.articleId}" method="post"
+              style="display:inline;">
             <input type="hidden" name="_method" value="DELETE"/>
             <button class="delete-button">삭제</button>
         </form>
@@ -29,28 +30,43 @@
             <div class="comment">
                 <p class="comment-author">${comment.userNickname}</p>
                 <p class="comment-content">${comment.content}</p>
-<%--                <span class="time">${comment.createdAt}</span>--%>
-                <fmt:parseDate value="${comment.createdAt}"
-                               pattern="yyyy-MM-dd'T'HH:mm" var="parsedDateTime" type="both" />
-                <fmt:formatDate pattern="yyyy.MM.dd HH:mm" value="${ parsedDateTime }" />
-<%--                <p class="comment-date"><fmt:formatDate value="${comment.createdAt}" pattern="YYYY. MM. DD. HH:mm"/></p>--%>
+                <p class="comment-date">
+                    <fmt:parseDate value="${comment.createdAt}"
+                                   pattern="yyyy-MM-dd'T'HH:mm" var="parsedDateTime" type="both"/>
+                    <fmt:formatDate pattern="yyyy.MM.dd HH:mm" value="${ parsedDateTime }"/>
+                </p>
+                <!-- 수정 폼 -->
+<%--                <form class="comment-edit" method="post" action="/comments/${comment.replyId}">--%>
+<%--                    <input type="hidden" name="_method" value="PUT">--%>
+<%--                    <input type="hidden" name="articleId" value="${article.articleId}">--%>
+<%--                    <input type="hidden" name="replyId" value="${comment.replyId}">--%>
+<%--                    <input type="hidden" name="content" value="${comment.content}">--%>
+<%--                    <button>수정</button>--%>
+<%--                </form>--%>
+                <!-- 삭제 폼 -->
+                <form class="comment-edit" method="post" action="/comments/${comment.replyId}">
+                    <input type="hidden" name="_method" value="DELETE">
+                    <input type="hidden" name="articleId" value="${article.articleId}">
+                    <input type="hidden" name="replyId" value="${comment.replyId}">
+                    <button>삭제</button>
+                </form>
             </div>
         </c:forEach>
     </div>
 
     <form class="comment-form" action="${pageContext.request.contextPath}/comments" method="post">
         <input type="hidden" name="articleId" value="${article.articleId}">
-<%--        <input type="hidden" name="userId" value="${sessionScope.userId}">--%>
+        <%--        <input type="hidden" name="userId" value="${sessionScope.userId}">--%>
         <input type="hidden" name="articleId" value="${article.articleId}">
         <textarea name="content" placeholder="댓글을 입력하세요"></textarea>
         <button type="submit">등록</button>
     </form>
 
     <div class="navigation-buttons">
-<%--        <div class="prev-next">--%>
-<%--            <a href="${pageContext.request.contextPath}/articles/${prevArticle.id}" class="prev-button">이전글: ${prevArticle.title}</a>--%>
-<%--            <a href="${pageContext.request.contextPath}/articles/${nextArticle.id}" class="next-button">다음글: ${nextArticle.title}</a>--%>
-<%--        </div>--%>
+        <%--        <div class="prev-next">--%>
+        <%--            <a href="${pageContext.request.contextPath}/articles/${prevArticle.id}" class="prev-button">이전글: ${prevArticle.title}</a>--%>
+        <%--            <a href="${pageContext.request.contextPath}/articles/${nextArticle.id}" class="next-button">다음글: ${nextArticle.title}</a>--%>
+        <%--        </div>--%>
         <a href="${pageContext.request.contextPath}/articles" class="list-button">목록으로</a>
     </div>
 </div>

--- a/src/main/webapp/WEB-INF/views/user/form.jsp
+++ b/src/main/webapp/WEB-INF/views/user/form.jsp
@@ -5,7 +5,7 @@
 
 
 <div class="login-container">
-    <h2>로그인</h2>
+    <h2>회원가입</h2>
     <form name="login" action="${pageContext.request.contextPath}/users/registration" method="post" class="login-form">
         <input type="email" id="email" name="email" placeholder="이메일을 입력해주세요" required>
         <input type="nickname" id="nickname" name="nickname" placeholder="닉네임을 입력해주세요" required>

--- a/src/main/webapp/static/css/common.css
+++ b/src/main/webapp/static/css/common.css
@@ -178,8 +178,8 @@ form input[type="text"] {
 }
 
 form button {
-    background-color: #5ac6b2;
-    color: white;
+    /*background-color: #5ac6b2;*/
+    /*color: white;*/
     padding: 10px 15px;
     border: none;
     border-radius: 4px;
@@ -187,7 +187,7 @@ form button {
 }
 
 button:hover {
-    background-color: #4ca899;
+    /*background-color: #4ca899;*/
 }
 
 form div {
@@ -209,8 +209,8 @@ label {
 /*}*/
 
 button {
-    background-color: #5ac6b2;
-    color: white;
+    /*background-color: #5ac6b2;*/
+    /*color: white;*/
     padding: 10px 15px;
     border: none;
     border-radius: 4px;
@@ -302,6 +302,7 @@ textarea.form-control {
     height: 300px; /* 높이를 이미지와 유사하게 조정 */
 }
 
+/* <button type="submit> 태그에 적용되는 css */
 button[type="submit"] {
     background-color: #5ac6b2;
     color: white;
@@ -431,10 +432,11 @@ button[type="submit"]:hover {
     min-height: 100px; /* 최소 높이 설정 */
 }
 
-.comment-form button {
+.comment-edit button{
     align-self: flex-end; /* 버튼을 오른쪽으로 정렬 */
-    background-color: #5ac6b2;
-    color: white;
+    background-color: transparent !important; /* 투명 배경 */
+    /*background-color: #f0f0f0;*/
+    color: #888;
     border: none;
     padding: 10px 20px;
     border-radius: 4px;

--- a/src/test/java/woowa/camp/jspcafe/repository/ArticleDBSetupExtension.java
+++ b/src/test/java/woowa/camp/jspcafe/repository/ArticleDBSetupExtension.java
@@ -37,7 +37,8 @@ public class ArticleDBSetupExtension implements BeforeEachCallback, AfterEachCal
                         content VARCHAR(5000) NOT NULL,
                         hits INT DEFAULT 0,
                         created_at DATE NOT NULL,
-                        updated_at DATE
+                        updated_at DATE,
+                        deleted_at DATE
                     )
                     """;
 

--- a/src/test/java/woowa/camp/jspcafe/repository/ArticleRepositoryTest.java
+++ b/src/test/java/woowa/camp/jspcafe/repository/ArticleRepositoryTest.java
@@ -18,17 +18,16 @@ import woowa.camp.jspcafe.repository.article.DBArticleRepository;
 import woowa.camp.jspcafe.utils.FixedDateTimeProvider;
 import woowa.camp.jspcafe.infra.time.DateTimeProvider;
 
+@ExtendWith(ArticleDBSetupExtension.class)
 class ArticleRepositoryTest {
 
+    DatabaseConnector connector = new DatabaseConnector();
+    ArticleRepository repository = new DBArticleRepository(connector);
     DateTimeProvider fixedDateTime = new FixedDateTimeProvider(2024, 7, 23);
 
     @Nested
     @DisplayName("Describe_게시글을 저장하는 기능은")
-    @ExtendWith(ArticleDBSetupExtension.class)
     class SaveTest {
-
-        DatabaseConnector connector = new DatabaseConnector();
-        ArticleRepository repository = new DBArticleRepository(connector);
 
         @Test
         @DisplayName("[Success] 게시글을 저장하면, 게시글 ID로 조회할 수 있다")
@@ -87,11 +86,7 @@ class ArticleRepositoryTest {
 
     @Nested
     @DisplayName("Describe_게시글을 id 기준으로 조회하는 기능은")
-    @ExtendWith(ArticleDBSetupExtension.class)
     class FindByIdTest {
-
-        DatabaseConnector connector = new DatabaseConnector();
-        ArticleRepository repository = new DBArticleRepository(connector);
 
         @Test
         @DisplayName("[Success] 특정 게시글을 조회할 수 있다")
@@ -142,11 +137,7 @@ class ArticleRepositoryTest {
 
     @Nested
     @DisplayName("Describe_이전 게시글을 조회하는 기능은")
-    @ExtendWith(ArticleDBSetupExtension.class)
     class FindPreviousTest {
-
-        DatabaseConnector connector = new DatabaseConnector();
-        ArticleRepository repository = new DBArticleRepository(connector);
 
         @Test
         @DisplayName("[Success] 이전 게시글을 조회할 수 있다")
@@ -182,11 +173,7 @@ class ArticleRepositoryTest {
 
     @Nested
     @DisplayName("Describe_다음 게시글을 조회하는 기능은")
-    @ExtendWith(ArticleDBSetupExtension.class)
     class FindNextTest {
-
-        DatabaseConnector connector = new DatabaseConnector();
-        ArticleRepository repository = new DBArticleRepository(connector);
 
         @Test
         @DisplayName("[Success] 다음 게시글을 조회할 수 있다")
@@ -222,11 +209,8 @@ class ArticleRepositoryTest {
 
     @Nested
     @DisplayName("Describe_오프셋 기반으로 게시글을 조회하는 기능은")
-    @ExtendWith(ArticleDBSetupExtension.class)
     class FindByOffsetPaginationTest {
 
-        DatabaseConnector connector = new DatabaseConnector();
-        ArticleRepository repository = new DBArticleRepository(connector);
         private static final int PAGE_SIZE = 10;
 
         @Test
@@ -322,11 +306,7 @@ class ArticleRepositoryTest {
 
     @Nested
     @DisplayName("게시글을 업데이트하는 기능은")
-    @ExtendWith(ArticleDBSetupExtension.class)
     class UpdateTest {
-
-        DatabaseConnector connector = new DatabaseConnector();
-        ArticleRepository repository = new DBArticleRepository(connector);
 
         Article originalArticle;
         Long originalArticleId;

--- a/src/test/java/woowa/camp/jspcafe/repository/reply/ReplyDBSetupExtension.java
+++ b/src/test/java/woowa/camp/jspcafe/repository/reply/ReplyDBSetupExtension.java
@@ -26,7 +26,7 @@ public class ReplyDBSetupExtension implements BeforeEachCallback, AfterEachCallb
 
             String createTableSQL = """
                     CREATE TABLE IF NOT EXISTS replies (
-                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        reply_id BIGINT AUTO_INCREMENT PRIMARY KEY,
                         user_id BIGINT,
                         article_id BIGINT,
                         content VARCHAR(255),

--- a/src/test/java/woowa/camp/jspcafe/repository/reply/ReplyDBSetupExtension.java
+++ b/src/test/java/woowa/camp/jspcafe/repository/reply/ReplyDBSetupExtension.java
@@ -1,0 +1,60 @@
+package woowa.camp.jspcafe.repository.reply;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import woowa.camp.jspcafe.infra.DatabaseConnector;
+
+public class ReplyDBSetupExtension implements BeforeEachCallback, AfterEachCallback {
+
+    private final DatabaseConnector connector;
+
+    public ReplyDBSetupExtension() {
+        this.connector = new DatabaseConnector();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        createTables();
+    }
+
+    private void createTables() {
+        try (Connection connection = connector.getConnection();
+             Statement statement = connection.createStatement()) {
+
+            String createTableSQL = """
+                    CREATE TABLE IF NOT EXISTS replies (
+                        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                        user_id BIGINT,
+                        article_id BIGINT,
+                        content VARCHAR(255),
+                        created_at DATETIME,
+                        updated_at DATETIME,
+                        deleted_at DATETIME
+                    )
+                    """;
+
+            statement.execute(createTableSQL);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create tables", e);
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
+        dropTables();
+    }
+
+    private void dropTables() {
+        try (var connection = connector.getConnection();
+             var statement = connection.createStatement()) {
+
+            String dropTableSQL = "DROP TABLE IF EXISTS replies";
+            statement.execute(dropTableSQL);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to drop tables", e);
+        }
+    }
+}

--- a/src/test/java/woowa/camp/jspcafe/repository/reply/ReplyRepositoryTest.java
+++ b/src/test/java/woowa/camp/jspcafe/repository/reply/ReplyRepositoryTest.java
@@ -329,7 +329,6 @@ class ReplyRepositoryTest {
             repository.save(reply2);
             // when
             List<ReplyResponse> result = repository.findByArticleIdWithUser(1L);
-            System.out.println("result = " + result);
             // then
             assertThat(result)
                     .hasSize(2)

--- a/src/test/java/woowa/camp/jspcafe/repository/reply/ReplyRepositoryTest.java
+++ b/src/test/java/woowa/camp/jspcafe/repository/reply/ReplyRepositoryTest.java
@@ -1,0 +1,298 @@
+package woowa.camp.jspcafe.repository.reply;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import woowa.camp.jspcafe.domain.Reply;
+import woowa.camp.jspcafe.infra.DatabaseConnector;
+import woowa.camp.jspcafe.utils.FixedDateTimeProvider;
+
+@ExtendWith(ReplyDBSetupExtension.class)
+class ReplyRepositoryTest {
+
+    DatabaseConnector connector = new DatabaseConnector();
+    ReplyRepository repository = new DBReplyRepository(connector);
+    FixedDateTimeProvider fixedDateTime = new FixedDateTimeProvider(2024, 7, 31);
+
+    @Nested
+    @DisplayName("Describe_댓글을 저장하는 기능은")
+    class SaveTest {
+
+        @Test
+        @DisplayName("[Success] 유효한 댓글 정보로 저장에 성공한다")
+        void saveValidReply() {
+            // given
+            Reply reply = new Reply(1L, 1L, "Test Comment",
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    null);
+            // when
+            Reply savedReply = repository.save(reply);
+            // then
+            assertThat(savedReply.getId()).isNotNull();
+            assertThat(savedReply)
+                    .usingRecursiveComparison()
+                    .isEqualTo(reply);
+        }
+
+        @Test
+        @DisplayName("[Exception] 유효하지 않은 사용자 ID로 저장 시 예외가 발생한다")
+        void saveWithInvalidUserId() {
+            // given
+            Reply reply = new Reply(null, 1L, "Test Comment",
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    null);
+
+            // when & then
+            assertThatThrownBy(() -> repository.save(reply))
+                    .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        @DisplayName("[Exception] 유효하지 않은 게시글 ID로 저장 시 예외가 발생한다")
+        void saveWithInvalidArticleId() {
+            // given
+            Reply reply = new Reply(1L, null, "Test Comment",
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    null);
+
+            // when & then
+            assertThatThrownBy(() -> repository.save(reply))
+                    .isInstanceOf(RuntimeException.class);
+        }
+
+        @Test
+        @DisplayName("[Exception] 내용이 없는 댓글 저장 시 예외가 발생한다")
+        void saveWithEmptyContent() {
+            // given
+            Reply reply = new Reply(1L, null, "",
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    null);
+
+            // when & then
+            assertThatThrownBy(() -> repository.save(reply))
+                    .isInstanceOf(RuntimeException.class);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Describe_ID기준으로 댓글을 조회하는 기능은")
+    class FindByIdTest {
+
+        @Test
+        @DisplayName("[Success] 존재하는 ID로 댓글을 성공적으로 조회한다")
+        void findExistingReply() {
+            // given
+            Reply reply = new Reply(1L, 1L, "Test Comment",
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    null);
+            Reply savedReply = repository.save(reply);
+
+            // when
+            Optional<Reply> foundReply = repository.findById(savedReply.getId());
+
+            // then
+            assertThat(foundReply)
+                    .isPresent()
+                    .get()
+                    .usingRecursiveComparison()
+                    .isEqualTo(savedReply);
+        }
+
+        @Test
+        @DisplayName("[Success] 존재하지 않는 ID로 조회 시 빈 Optional을 반환한다")
+        void findNonExistingReply() {
+            // given
+            Long nonExistingId = 9999L;
+
+            // when
+            Optional<Reply> foundReply = repository.findById(nonExistingId);
+
+            // then
+            assertThat(foundReply).isEmpty();
+        }
+
+        @Test
+        @DisplayName("[Success] 음수 ID로 조회 시 예외가 발생하지 않는다")
+        void findReplyWithNegativeId() {
+            // given
+            Long negativeId = -1L;
+
+            // when & then
+            assertThatCode(() -> repository.findById(negativeId))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("[Exception] 유효하지 않은 ID로 조회 시 예외가 발생하지 않는다")
+        void findReplyWithNullId() {
+            // given
+            Long negativeId = null;
+
+            // when & then
+            assertThatThrownBy(() -> repository.findById(negativeId))
+                    .isInstanceOf(RuntimeException.class);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Describe_게시글ID기준으로 댓글을 조회하는 기능은")
+    class FindByArticleIdTest {
+
+        @Test
+        @DisplayName("[Success] 존재하는 게시글 ID로 댓글 목록을 성공적으로 조회한다")
+        void findRepliesForExistingArticle() {
+            // given
+            Long articleId = 1L;
+            Reply reply1 = new Reply(1L, 1L, "Test Comment 1",
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    null);
+            Reply reply2 = new Reply(2L, 1L, "Test Comment 1",
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    null);
+            repository.save(reply1);
+            repository.save(reply2);
+
+            // when
+            List<Reply> replies = repository.findByArticleId(articleId);
+
+            // then
+            assertThat(replies)
+                    .hasSize(2)
+                    .allMatch(r -> r.getArticleId().equals(articleId));
+        }
+
+        @Test
+        @DisplayName("[Success] 존재하지 않는 게시글 ID로 조회 시 빈 리스트를 반환한다")
+        void findRepliesForNonExistingArticle() {
+            // given
+            Long nonExistingArticleId = 9999L;
+
+            // when
+            List<Reply> replies = repository.findByArticleId(nonExistingArticleId);
+
+            // then
+            assertThat(replies).isEmpty();
+        }
+
+        @Test
+        @DisplayName("[Success] 음수 게시글 ID로 조회 시 빈 리스트를 반환한다")
+        void findRepliesWithNegativeArticleId() {
+            // given
+            Long negativeArticleId = -1L;
+
+            // when & then
+            List<Reply> result = repository.findByArticleId(negativeArticleId);
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("[Exception] 유효하지 않은 게시글 ID로 조회 시 예외를 반환한다")
+        void findRepliesWithNullArticleId() {
+            // given
+            Long negativeArticleId = null;
+
+            // when & then
+            assertThatThrownBy(() -> repository.findByArticleId(negativeArticleId))
+                    .isInstanceOf(RuntimeException.class);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Describe_회원ID기준으로 댓글을 소프트 삭제하는 기능은")
+    class SoftDeleteByUserIdTest {
+
+        @Test
+        @DisplayName("[Success] 존재하는 회원 ID로 댓글을 성공적으로 소프트 삭제한다")
+        void softDeleteRepliesForExistingUser() {
+            // given
+            Long userId1 = 1L;
+            Long userId2 = 2L;
+            Reply reply1 = new Reply(userId1, 1L, "Test Comment 1",
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    null);
+            Reply reply2 = new Reply(userId2, 1L, "Test Comment 1",
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(),
+                    null);
+            repository.save(reply1);
+            repository.save(reply2);
+
+            // when
+            LocalDateTime deletedTime = fixedDateTime.getNowAsLocalDateTime();
+            repository.softDeleteByUserId(userId1, deletedTime);
+            repository.softDeleteByUserId(userId2, deletedTime);
+
+            // then
+            List<Reply> repliesForArticle1 = repository.findByArticleId(1L);
+            assertThat(repliesForArticle1).isEmpty();
+        }
+
+        @Test
+        @DisplayName("[Success] 존재하지 않는 회원 ID로 소프트 삭제 시 예외가 발생하지 않는다")
+        void softDeleteRepliesForNonExistingUser() {
+            // given
+            Long nonExistingUserId = 9999L;
+
+            // when & then
+            assertThatCode(() -> repository.softDeleteByUserId(nonExistingUserId, LocalDateTime.now()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("[Success] 음수 회원 ID로 소프트 삭제 시 예외가 발생하지 않는다")
+        void softDeleteRepliesWithNegativeUserId() {
+            // given
+            Long negativeUserId = -1L;
+
+            // when & then
+            assertThatCode(() -> repository.softDeleteByUserId(negativeUserId, LocalDateTime.now()))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("[Exception] 유효하지 않은 사용자 ID로 소프트 삭제 시 예외가 발생한다")
+        void softDeleteRepliesWithNullUserId() {
+            // given
+            Long negativeUserId = null;
+
+            // when & then
+            assertThatThrownBy(() -> repository.softDeleteByUserId(negativeUserId, LocalDateTime.now()))
+                    .isInstanceOf(RuntimeException.class);
+        }
+
+//        서비스 레이어에서 테스트 해야 함
+//        @Test
+//        @DisplayName("[Exception] 과거 시간으로 소프트 삭제 시 예외가 발생한다")
+//        void softDeleteRepliesWithPastTime() {
+//            // given
+//            Long userId = 1L;
+//            LocalDateTime pastTime = LocalDateTime.now().minusDays(1);
+//
+//            // when & then
+//            assertThatThrownBy(() -> repository.softDeleteByUserId(userId, pastTime))
+//                    .isInstanceOf(RuntimeException.class);
+//        }
+
+    }
+
+
+}

--- a/src/test/java/woowa/camp/jspcafe/service/ArticleServiceTest.java
+++ b/src/test/java/woowa/camp/jspcafe/service/ArticleServiceTest.java
@@ -21,6 +21,7 @@ import woowa.camp.jspcafe.repository.ArticleDBSetupExtension;
 import woowa.camp.jspcafe.repository.article.ArticleRepository;
 import woowa.camp.jspcafe.repository.article.DBArticleRepository;
 import woowa.camp.jspcafe.repository.dto.ArticleUpdateRequest;
+import woowa.camp.jspcafe.repository.reply.ReplyRepository;
 import woowa.camp.jspcafe.repository.user.InMemoryUserRepository;
 import woowa.camp.jspcafe.repository.user.UserRepository;
 import woowa.camp.jspcafe.service.dto.ArticleDetailsResponse;
@@ -35,6 +36,7 @@ class ArticleServiceTest {
     private DatabaseConnector databaseConnector;
     private ArticleRepository articleRepository;
     private UserRepository userRepository;
+    private ReplyRepository replyRepository;
     private DateTimeProvider fixedDateTime;
     private ArticleService articleService;
 
@@ -44,7 +46,7 @@ class ArticleServiceTest {
         articleRepository = new DBArticleRepository(databaseConnector);
         userRepository = new InMemoryUserRepository();
         fixedDateTime = new FixedDateTimeProvider(2024, 7, 25);
-        articleService = new ArticleService(articleRepository, userRepository, fixedDateTime);
+        articleService = new ArticleService(articleRepository, userRepository, replyRepository, fixedDateTime);
     }
 
     @Nested

--- a/src/test/java/woowa/camp/jspcafe/service/ArticleServiceTest.java
+++ b/src/test/java/woowa/camp/jspcafe/service/ArticleServiceTest.java
@@ -354,7 +354,7 @@ class ArticleServiceTest {
         }
 
         @Test
-        @DisplayName("[Success] 게시글 작성자의 댓글만 있는 경우 게시글 삭제가 가능하다")
+        @DisplayName("[Success] 게시글 작성자의 댓글만 있는 경우 게시글 삭제가 가능하고 댓글도 모두 삭제된다")
         void deleteArticleWithOnlyAuthorReplies() {
             // given
             Long articleId = article1.getId();

--- a/src/test/java/woowa/camp/jspcafe/service/ReplyServiceTest.java
+++ b/src/test/java/woowa/camp/jspcafe/service/ReplyServiceTest.java
@@ -1,0 +1,285 @@
+package woowa.camp.jspcafe.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import woowa.camp.jspcafe.domain.Article;
+import woowa.camp.jspcafe.domain.Reply;
+import woowa.camp.jspcafe.domain.User;
+import woowa.camp.jspcafe.domain.exception.ArticleException;
+import woowa.camp.jspcafe.domain.exception.ReplyException;
+import woowa.camp.jspcafe.domain.exception.UnAuthorizationException;
+import woowa.camp.jspcafe.domain.exception.UserException;
+import woowa.camp.jspcafe.fixture.UserFixture;
+import woowa.camp.jspcafe.infra.DatabaseConnector;
+import woowa.camp.jspcafe.infra.time.DateTimeProvider;
+import woowa.camp.jspcafe.repository.ArticleDBSetupExtension;
+import woowa.camp.jspcafe.repository.UserDBSetupExtension;
+import woowa.camp.jspcafe.repository.article.ArticleRepository;
+import woowa.camp.jspcafe.repository.article.DBArticleRepository;
+import woowa.camp.jspcafe.repository.reply.DBReplyRepository;
+import woowa.camp.jspcafe.repository.reply.ReplyDBSetupExtension;
+import woowa.camp.jspcafe.repository.reply.ReplyRepository;
+import woowa.camp.jspcafe.repository.user.DBUserRepository;
+import woowa.camp.jspcafe.repository.user.UserRepository;
+import woowa.camp.jspcafe.service.dto.ReplyResponse;
+import woowa.camp.jspcafe.service.dto.ReplyWriteRequest;
+import woowa.camp.jspcafe.utils.FixedDateTimeProvider;
+
+@ExtendWith({ReplyDBSetupExtension.class, UserDBSetupExtension.class, ArticleDBSetupExtension.class})
+class ReplyServiceTest {
+
+    DateTimeProvider fixedDateTime = new FixedDateTimeProvider(2024, 8, 1);
+
+    DatabaseConnector connector = new DatabaseConnector();
+    UserRepository userRepository = new DBUserRepository(connector);
+    ArticleRepository articleRepository = new DBArticleRepository(connector);
+    ReplyRepository replyRepository = new DBReplyRepository(connector);
+
+    ReplyService replyService = new ReplyService(replyRepository, userRepository, fixedDateTime);
+
+    @Nested
+    @DisplayName("Describe_댓글을 작성하는 기능은")
+    class WriteReplyTest {
+
+        @Test
+        @DisplayName("[Success] 생성/수정 날짜는 현재 시간으로 동일하며, 삭제 날짜는 값이 없다")
+        void success() {
+            // given
+            Reply reply = replyService.writeReply(new ReplyWriteRequest(1L, 2L, "댓글 내용"));
+            // when
+
+            // then
+            assertThat(reply.getCreatedAt()).isEqualTo(fixedDateTime.getNowAsLocalDateTime());
+            assertThat(reply.getUpdatedAt()).isEqualTo(fixedDateTime.getNowAsLocalDateTime());
+            assertThat(reply.getDeletedAt()).isNull();
+            assertThat(reply.getUserId()).isEqualTo(1L);
+            assertThat(reply.getArticleId()).isEqualTo(2L);
+            assertThat(reply.getContent()).isEqualTo("댓글 내용");
+        }
+    }
+
+    @Nested
+    @DisplayName("Describe_댓글 목록을 조회하는 기능은")
+    class FindReplyListTest {
+
+        @Test
+        @DisplayName("[Success] 게시글 ID 기준으로 댓글 작성자 정보와 함께 조회한다")
+        void test() {
+            // given
+            User replier = new User("email@email.com", "nickname", "password", fixedDateTime.getNow());
+            Long replierId = userRepository.save(replier);
+
+            Article article = new Article(replier.getId(), "게시글 제목", "게시글 내용", 1, fixedDateTime.getNow(),
+                    fixedDateTime.getNow());
+            Long articleId = articleRepository.save(article);
+
+            Reply reply = new Reply(replierId, articleId, "댓글 내용", fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(), null);
+            replyRepository.save(reply);
+
+            // when
+            List<ReplyResponse> result = replyService.findReplyList(articleId);
+
+            // then
+            assertThat(result.size()).isEqualTo(1);
+            ReplyResponse replyResponse = result.get(0);
+            assertReplyResponse(replyResponse, reply, replier);
+        }
+
+        private void assertReplyResponse(ReplyResponse replyResponse, Reply reply, User replier) {
+            assertThat(replyResponse.getReplyId()).isEqualTo(reply.getReplyId());
+            assertThat(replyResponse.getCreatedAt()).isEqualTo(reply.getCreatedAt());
+            assertThat(replyResponse.getContent()).isEqualTo(reply.getContent());
+            assertThat(replyResponse.getUserId()).isEqualTo(reply.getUserId());
+            assertThat(replyResponse.getUserNickname()).isEqualTo(replier.getNickname());
+        }
+
+        @Test
+        @DisplayName("[Success] 게시글에 작성된 댓글 개수만큼 조회한다")
+        void test3() {
+            // given
+            Long articleId = 1L;
+            Long count = 30L;
+            List<User> users = UserFixture.createMultipleUsers(30, fixedDateTime.getNow());
+            for (User user : users) {
+                userRepository.save(user);
+            }
+            List<Reply> replies = createMultipleReplies(count, articleId, fixedDateTime.getNowAsLocalDateTime());
+            for (Reply reply : replies) {
+                replyRepository.save(reply);
+            }
+            // when
+            List<ReplyResponse> replyList = replyService.findReplyList(articleId);
+            // then
+            assertThat(replyList.size()).isEqualTo(30);
+        }
+
+        @Test
+        @DisplayName("[Success] 댓글 작성자에 해당하는 사용자가 없으면 조회하지 않는다")
+        void test4() {
+            // given
+            Long articleId = 1L;
+            Long count = 30L;
+            List<Reply> replies = createMultipleReplies(count, articleId, fixedDateTime.getNowAsLocalDateTime());
+            for (Reply reply : replies) {
+                replyRepository.save(reply);
+            }
+
+            // when
+            List<ReplyResponse> replyList = replyService.findReplyList(articleId);
+
+            // then
+            assertThat(replyList.size()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("[Success] 없는 게시글 ID로 조회할 경우 빈 리스트를 반환한다")
+        void test2() {
+            // given
+            User replier = new User("email@email.com", "nickname", "password", fixedDateTime.getNow());
+            Long replierId = userRepository.save(replier);
+
+            Article article = new Article(replier.getId(), "게시글 제목", "게시글 내용", 1, fixedDateTime.getNow(),
+                    fixedDateTime.getNow());
+            Long articleId = articleRepository.save(article);
+
+            Reply reply = new Reply(replierId, articleId, "댓글 내용", fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(), null);
+            replyRepository.save(reply);
+
+            // when
+            List<ReplyResponse> result = replyService.findReplyList(123456L);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        public List<Reply> createMultipleReplies(Long count, Long articleId, LocalDateTime now) {
+            return LongStream.rangeClosed(1, count)
+                    .mapToObj(i -> createReply(count, articleId, now))
+                    .toList();
+        }
+
+        public Reply createReply(Long number, Long articleId, LocalDateTime now) {
+            return new Reply(number, articleId, "댓글 내용", now, now, null);
+        }
+
+    }
+
+    @Nested
+    @DisplayName("Describe_댓글을 삭제하는 기능은")
+    class DeleteReplyTest {
+
+        @Test
+        @DisplayName("[Success] 정상적으로 댓글을 삭제한다")
+        void deleteReplySuccessfully() {
+            // given
+            User user = new User("user@email.com", "nickname", "password", fixedDateTime.getNow());
+            Long userId = userRepository.save(user);
+
+            Article article = new Article(userId, "제목", "내용", 0, fixedDateTime.getNow(), fixedDateTime.getNow());
+            Long articleId = articleRepository.save(article);
+
+            Reply reply = new Reply(userId, articleId, "댓글 내용", fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(), null);
+            Reply saveReply = replyRepository.save(reply);
+
+            // when
+            replyService.deleteReply(user, articleId, saveReply.getReplyId());
+
+            // then
+            assertThat(replyRepository.findById(saveReply.getReplyId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("[Exception] 존재하지 않는 댓글ID면 ReplyException 예외가 발생한다")
+        void throwReplyExceptionForNonExistentReply() {
+            // given
+            User user = new User("user@email.com", "nickname", "password", fixedDateTime.getNow());
+            userRepository.save(user);
+
+            Long nonExistentReplyId = 9999L;
+
+            // when & then
+            assertThatThrownBy(() -> replyService.deleteReply(user, 1L, nonExistentReplyId))
+                    .isInstanceOf(ReplyException.class)
+                    .hasMessageContaining("Reply not found");
+        }
+
+        @Test
+        @DisplayName("[Exception] 댓글 작성자의 회원ID가 존재하지 않으면 UserException 예외가 발생한다")
+        void throwUserExceptionForNonExistentUser() {
+            // given
+            User user = new User("user@email.com", "nickname", "password", fixedDateTime.getNow());
+            Long userId = userRepository.save(user);
+
+            Article article = new Article(userId, "제목", "내용", 0, fixedDateTime.getNow(), fixedDateTime.getNow());
+            Long articleId = articleRepository.save(article);
+
+            Reply reply = new Reply(9999L, articleId, "댓글 내용", fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(), null);
+            Reply saveReply = replyRepository.save(reply);
+
+            // when & then
+            assertThatThrownBy(() -> replyService.deleteReply(user, articleId, saveReply.getReplyId()))
+                    .isInstanceOf(UserException.class)
+                    .hasMessageContaining("User with id 9999 not found");
+        }
+
+        @Test
+        @DisplayName("[Exception] 댓글을 삭제하려는 회원과 댓글 작성자의 이메일이 일치하지 않으면 UnAuthorizationException 예외가 발생한다")
+        void throwUnAuthorizationExceptionForUnauthorizedUser() {
+            // given
+            User author = new User("author@email.com", "author", "password", fixedDateTime.getNow());
+            Long authorId = userRepository.save(author);
+
+            User unauthorizedUser = new User("unauthorized@email.com", "unauthorized", "password",
+                    fixedDateTime.getNow());
+            userRepository.save(unauthorizedUser);
+
+            Article article = new Article(authorId, "제목", "내용", 0, fixedDateTime.getNow(), fixedDateTime.getNow());
+            Long articleId = articleRepository.save(article);
+
+            Reply reply = new Reply(authorId, articleId, "댓글 내용", fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(), null);
+            Reply saveReply = replyRepository.save(reply);
+
+            // when & then
+            assertThatThrownBy(() -> replyService.deleteReply(unauthorizedUser, articleId, saveReply.getReplyId()))
+                    .isInstanceOf(UnAuthorizationException.class)
+                    .hasMessageContaining("게시글 수정은 작성자의 이메일과 동일해야 합니다");
+        }
+
+        @Test
+        @DisplayName("[Exception] 요청으로 받은 게시글 ID와 댓글의 게시글 ID가 일치하지 않으면 ArticleException 예외가 발생한다")
+        void throwArticleExceptionForMismatchedArticleId() {
+            // given
+            User user = new User("user@email.com", "nickname", "password", fixedDateTime.getNow());
+            Long userId = userRepository.save(user);
+
+            Article article = new Article(userId, "제목", "내용", 0, fixedDateTime.getNow(), fixedDateTime.getNow());
+            Long articleId = articleRepository.save(article);
+
+            Reply reply = new Reply(userId, articleId, "댓글 내용", fixedDateTime.getNowAsLocalDateTime(),
+                    fixedDateTime.getNowAsLocalDateTime(), null);
+            Reply saveReply = replyRepository.save(reply);
+
+            Long mismatchedArticleId = articleId + 1;
+
+            // when & then
+            assertThatThrownBy(() -> replyService.deleteReply(user, mismatchedArticleId, saveReply.getReplyId()))
+                    .isInstanceOf(ArticleException.class)
+                    .hasMessageContaining("편집하려는 댓글의 게시글 id와 일치하지 않습니다");
+        }
+
+    }
+
+}

--- a/src/test/java/woowa/camp/jspcafe/service/UserServiceTest.java
+++ b/src/test/java/woowa/camp/jspcafe/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package woowa.camp.jspcafe.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -108,10 +109,24 @@ class UserServiceTest {
         void test() {
             User user1 = UserFixture.createUser1();
             User user2 = UserFixture.createUser2();
-            userRepository.save(user1);
-            userRepository.save(user2);
+            Long user1Id = userRepository.save(user1);
+            Long user2Id = userRepository.save(user2);
             List<UserResponse> result = userService.findAll();
             assertThat(result).size().isEqualTo(2);
+
+            assertThat(result)
+                    .hasSize(2)
+                    .satisfies(userResponses -> {
+                        assertThat(userResponses).extracting(
+                                UserResponse::getEmail,
+                                UserResponse::getId,
+                                UserResponse::getNickname,
+                                UserResponse::getRegisterAt
+                        ).containsExactly(
+                                tuple(user1.getEmail(), user1Id, user1.getNickname(), user1.getRegisterAt()),
+                                tuple(user2.getEmail(), user2Id, user2.getNickname(), user2.getRegisterAt())
+                        );
+                    });
         }
     }
 

--- a/src/test/java/woowa/camp/jspcafe/service/UserServiceTest.java
+++ b/src/test/java/woowa/camp/jspcafe/service/UserServiceTest.java
@@ -9,27 +9,34 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import woowa.camp.jspcafe.domain.User;
 import woowa.camp.jspcafe.domain.exception.UserException;
 import woowa.camp.jspcafe.fixture.UserFixture;
+import woowa.camp.jspcafe.infra.DatabaseConnector;
+import woowa.camp.jspcafe.infra.time.DateTimeProvider;
+import woowa.camp.jspcafe.repository.UserDBSetupExtension;
+import woowa.camp.jspcafe.repository.dto.UserUpdateRequest;
+import woowa.camp.jspcafe.repository.user.DBUserRepository;
 import woowa.camp.jspcafe.repository.user.InMemoryUserRepository;
 import woowa.camp.jspcafe.repository.user.UserRepository;
 import woowa.camp.jspcafe.service.dto.RegistrationRequest;
 import woowa.camp.jspcafe.service.dto.UserResponse;
 import woowa.camp.jspcafe.utils.FixedDateTimeProvider;
-import woowa.camp.jspcafe.infra.time.DateTimeProvider;
 
+@ExtendWith(UserDBSetupExtension.class)
 class UserServiceTest {
+
+    DatabaseConnector connector = new DatabaseConnector();
+    UserRepository userRepository = new DBUserRepository(connector);
+    DateTimeProvider fixedDateTimeProvider = new FixedDateTimeProvider(2024, 7, 24);
+    UserService userService = new UserService(userRepository, fixedDateTimeProvider);
 
     @Nested
     @DisplayName("Describe_회원가입 기능은")
     class RegistrationTest {
-
-        DateTimeProvider fixedDateTimeProvider = new FixedDateTimeProvider(2024, 7, 24);
-        UserRepository userRepository = new InMemoryUserRepository();
-        UserService userService = new UserService(userRepository, fixedDateTimeProvider);
 
         @Test
         @DisplayName("[Success] 아이디, 비밀번호, 이름, 이메일 정보가 모두 있어야 회원가입을 성공한다")
@@ -112,10 +119,6 @@ class UserServiceTest {
     @DisplayName("Describe_사용자를 조회하는 기능은")
     class FindByIdTest {
 
-        DateTimeProvider fixedDateTimeProvider = new FixedDateTimeProvider(2024, 7, 24);
-        UserRepository userRepository = new InMemoryUserRepository();
-        UserService userService = new UserService(userRepository, fixedDateTimeProvider);
-
         @Test
         @DisplayName("[Success] 회원가입한 사용자는 조회에 성공한다")
         void test1() {
@@ -131,6 +134,101 @@ class UserServiceTest {
         @DisplayName("[Exception] 없는 사용자를 조회하면 예외가 발생한다")
         void test2() {
             assertThatThrownBy(() -> userService.findById(987654321L))
+                    .isInstanceOf(UserException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Describe_사용자 프로필을 수정하는 기능은")
+    class UpdateUserProfileTest {
+
+
+        @Test
+        @DisplayName("[Success] 비밀번호가 일치하면 프로필 수정에 성공한다")
+        void test() {
+            // given
+            User user = UserFixture.createUser(1, fixedDateTimeProvider.getNow());
+            userRepository.save(user);
+            String newPassword = "new password";
+            String newNickname = "new nickname";
+            UserUpdateRequest userUpdateRequest = new UserUpdateRequest(newPassword, newNickname);
+
+            // when
+            userService.updateUserProfile(user.getId(), user.getPassword(), userUpdateRequest);
+
+            // then
+            User findUser = userRepository.findById(user.getId()).orElseThrow();
+            assertThat(findUser.getPassword()).isEqualTo(newPassword);
+            assertThat(findUser.getNickname()).isEqualTo(newNickname);
+        }
+
+        @Test
+        @DisplayName("[Exception] 비밀번호가 일치하지 않으면 UserException 예외를 반환한다")
+        void test2() {
+            // given
+            User user = UserFixture.createUser(1, fixedDateTimeProvider.getNow());
+            userRepository.save(user);
+            String wrongPassword = "wrong password";
+            String newPassword = "new password";
+            String newNickname = "new nickname";
+            UserUpdateRequest userUpdateRequest = new UserUpdateRequest(newPassword, newNickname);
+
+            // when then
+            assertThatThrownBy(() -> userService.updateUserProfile(user.getId(), wrongPassword, userUpdateRequest))
+                    .isInstanceOf(UserException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("Describe_로그인하는 기능은")
+    class LoginTest {
+
+        @Test
+        @DisplayName("[Success] 이메일과 비밀번호가 같으면 User를 반환한다")
+        void sameEmailAndPassword() {
+            // given
+            User user = new User("email@naver.com", "닉네임", "password", fixedDateTimeProvider.getNow());
+            userRepository.save(user);
+
+            // when
+            User loginUser = userService.login(user.getEmail(), user.getPassword());
+            // then
+            assertThat(user).isEqualTo(loginUser);
+        }
+
+        @Test
+        @DisplayName("[Exception] 이메일이 다르면 UserException을 반환한다")
+        void wrongEmail() {
+            // given
+            User user = new User("email@naver.com", "닉네임", "password", fixedDateTimeProvider.getNow());
+            userRepository.save(user);
+
+            // when then
+            assertThatThrownBy(() -> userService.login("email1@naver.com", user.getPassword()))
+                    .isInstanceOf(UserException.class);
+        }
+
+        @Test
+        @DisplayName("[Exception] 비밀번호가 다르면 UserException을 반환한다")
+        void wrongPassword() {
+            // given
+            User user = new User("email@naver.com", "닉네임", "password", fixedDateTimeProvider.getNow());
+            userRepository.save(user);
+
+            // when then
+            assertThatThrownBy(() -> userService.login(user.getEmail(), "password!"))
+                    .isInstanceOf(UserException.class);
+        }
+
+        @Test
+        @DisplayName("[Exception] 아이디와 비밀번호가 다르면 UserException을 반환한다")
+        void wrongEmailAndPassword() {
+            // given
+            User user = new User("email@naver.com", "닉네임", "password", fixedDateTimeProvider.getNow());
+            userRepository.save(user);
+
+            // when then
+            assertThatThrownBy(() -> userService.login("emaill@naver.com", "password!"))
                     .isInstanceOf(UserException.class);
         }
     }

--- a/src/test/java/woowa/camp/jspcafe/utils/FixedDateTimeProvider.java
+++ b/src/test/java/woowa/camp/jspcafe/utils/FixedDateTimeProvider.java
@@ -1,6 +1,7 @@
 package woowa.camp.jspcafe.utils;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import woowa.camp.jspcafe.infra.time.DateTimeProvider;
 
 public class FixedDateTimeProvider implements DateTimeProvider {
@@ -14,6 +15,10 @@ public class FixedDateTimeProvider implements DateTimeProvider {
     @Override
     public LocalDate getNow() {
         return fixedTime;
+    }
+
+    public LocalDateTime getNowAsLocalDateTime() {
+        return fixedTime.atStartOfDay();
     }
 
 }

--- a/src/test/java/woowa/camp/jspcafe/utils/FixedDateTimeProvider.java
+++ b/src/test/java/woowa/camp/jspcafe/utils/FixedDateTimeProvider.java
@@ -17,6 +17,7 @@ public class FixedDateTimeProvider implements DateTimeProvider {
         return fixedTime;
     }
 
+    @Override
     public LocalDateTime getNowAsLocalDateTime() {
         return fixedTime.atStartOfDay();
     }


### PR DESCRIPTION
## 구현 내용
### 기능 목록
- [x]  댓글 작성 기능

```
요구사항:

댓글을 저장할 수 있다. ✅
로그인한 사용자는 댓글을 작성할 수 있다. ✅

댓글을 작성하면 현재 게시글로 리다이렉트한다. ✅
댓글을 작성하면 현재 게시글에서 볼 수 있다. ✅
```

- [x]  댓글 조회 기능

```
요구사항:

게시글을 기준으로 댓글 목록을 조회할 수 있다. ✅
```

- [x]  댓글 삭제 기능

```
요구사항:

- 자신이 쓴 댓글에 한해 댓글을 삭제할 수 있다. ✅
- 댓글 삭제는 soft delete로 구현한다. ✅
  - 댓글 삭제 시, deletedAt 날짜가 기록된다.
```

- [x]  게시글 삭제 기능 (추가 요구사항)

```
요구사항:

- 게시글 삭제를 soft delete로 변경한다. ✅
  - 게시글 삭제 시, deletedAt 날짜가 기록된다.

- 게시글을 삭제할 수 있는 요구사항은 아래와 같다.
  - 댓글을 삭제하려는 회원과 게시글 작성자가 같은 경우만 삭제 가능 ✅
  - 댓글이 없는 경우 삭제 가능 ✅
  - 게시글 작성자의 댓글만 있는 경우 삭제 가능 ✅
  - 게시글 작성자가 아닌 회원이 작성한 댓글이 있는 경우 삭제 불가 ✅

- 게시글 삭제 시, 게시글 작성자가 작성한 댓글도 모두 삭제 ✅
```

<br> <br>
### 각 기능에 따른 url과 메소드 convention (지속 갱신중)
URI | Method | 기능 | 담당 서블릿 | 인증
-- | -- | -- | -- | --
회원 |   |   |   |  
/users | GET | 회원 목록 조회 | UserServlet | O
/users/{userId}/ | GET | 회원 상세 조회 | UserServlet | O
/users/edit/{userId} | GET | 회원 정보 수정 폼 조회 | UserEditServlet | O
/users/edit/{userId} | POST | 회원 정보 수정 처리 | UserEditServlet | O
/users/registration | GET | 회원 가입 폼 조회 | UserRegistrationServlet | X
/users/registration | POST | 회원 가입 처리 | UserRegistrationServlet | X
/users/login | GET | 로그인 폼 조회 | UserLoginServlet | X
/users/login | POST | 로그인 처리 | UserLoginServlet | X
/users/logout | POST | 로그아웃 처리 | UserLogoutServlet | O
  |   |   |   |  
게시글 |   |   |   |  
/articles?page=xxx | GET | 게시글 목록 N개 조회 | ArticleServlet | X
/articles/{articleId} | GET | 게시글 상세 조회 | ArticleServlet | O
/articles/write | GET | 게시글 작성 폼 조회 | ArticleWriteServlet | O
/articles/write | POST | 게시글 작성 | ArticleWriteServlet | O
/articles/edit | GET | 게시글 수정 폼 조회 | ArticleEditServlet | O
/articles/edit/{articleId} | PUT | 게시글 수정 | ArticleEditServlet | O
/articles/edit/{articleId} | DELETE | 게시글 삭제 | ArticleEditServlet | O
  |   |   |   |  
댓글 |   |   |   |  
/comments | POST | 게시글 댓글 작성 | CommentServlet | O
/comments | GET | 게시글 댓글 목록 조회 | CommentServlet | O
/comments/{commentId} | DELETE | 댓글 삭제 | CommentServlet | O
  |   |   |   |  

<br> <br>

## 고민 사항
### 게시글 댓글 API URI와 담당 서블릿
댓글 작성, 댓글 목록 조회, 댓글 수정 등 댓글과 관련한 Request URI를 어떻게 설계할지 고민했습니다. 최초에 설계했던 URI는 다음과 같습니다.

URI | Method | 기능 | 담당 서블릿
-- | -- | -- | --
/articles/{articleId}comments | POST | 게시글 댓글 작성 | ArticleServlet
/articles/{articleId}/comments | GET | 게시글 댓글 목록 조회 | ArticleServlet
/articles/{articleId}/comments/{commentId} | DELETE | 댓글 삭제 | ArticleServlet
  |   |   |  

댓글은 특정 게시글에 종속적이므로, URI에 데이터 자원을 명시할 수 있는 API를 설계하고 싶었습니다. 하지만 URI 패턴 `/articles/*` 에 매핑되어 있는 ArticleServlet이 댓글 관련 요청도 처리하게 되고, 기존에 처리하고 있던 로직들과 합쳐지게 됩니다. 구현은 가능하나, 유지보수가 어려운 코드가 될 것이라 생각들어 고민했던 부분입니다. 따라서 아래와 같이 URI를 설계함으로서 데이터 자원의 명시성은 비교적 떨어지지만, 유지보수성과 실용성을 챙기고자 했습니다.

URI | Method | 기능 | 담당 서블릿
-- | -- | -- | --
/comments | POST | 게시글 댓글 작성 | CommentServlet
/comments | GET | 게시글 댓글 목록 조회 | CommentServlet
/comments/{commentId} | DELETE | 댓글 삭제 | CommentServlet
  |   |   |  

<br> <br>
### 게시글 삭제 요청 시, 다른 사람 댓글이 있는 경우에 대한 HTTP 상태코드
게시글 삭제 추가 요구사항을 구현하며, 하기의 고민들을 했습니다.
- 클라이언트가 잘못된 요청(400)을 보낸 것은 아니라고 생각한다.
- 또한 404도 아니다.
- 단지, **비즈니스 요구사항에 의해** 게시글을 삭제하지 못할 뿐이다.
- 요청 자체는 잘 보낸게 맞고, 처리(다른 사람 댓글에 의해 삭제 못함)도 잘 되었으니 200 OK로 내려주는게 맞지 않을까?

여기서 `409 Conflict` 대안을 고려해볼 수 있겠습니다. `409 Conflict`는 클라이언트 요청이 현재 서버의 상태와 충돌할 때 사용되는 상태코드입니다. 여기서는 삭제 요청이 비즈니스 규칙(다른 사용자의 댓글이 있는 게시글은 삭제할 수 없음)과 충돌하며, 이는 클라이언트의 요청이 잘못된 것이 아니라, 서버의 현재 상태나 규칙과 맞지 않음을 나타내므로 적합하다 생각들었습니다.

아직은 비즈니스 예외는 `400 Bad Request`로 통일하여 핸들링하고 있으나, 다음 미션에서 도입을 고민중에 있습니다.

## 기타
### 테스트 코드
서비스 계층, 레포지토리 계층에 대한 테스트를 보충하였습니다. 특히, 비즈니스 요구사항을 담고 있는 서비스 계층은 테스트가 반드시 필요하다 생각하여, 테스트 커버리지 100%를 달성하고자 했습니다.

<img width="884" alt="image" src="https://github.com/user-attachments/assets/3087af4c-ec36-48b0-9443-02f1e26058f3">

<br> <br>

### 댓글 작성 / 삭제, 게시글 삭제 시연 화면
![jsp_cafe_댓글](https://github.com/user-attachments/assets/86514c2e-e6d8-45b1-bc15-455e01cb2889)
