### PR TITLE
[김현욱] step-6, step-7 댓글, ajax 댓글 구현

### DIFF
--- a/src/main/java/com/hyeonuk/jspcafe/article/dao/InMemoryArticleDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/dao/InMemoryArticleDao.java
@@ -3,10 +3,7 @@ package com.hyeonuk.jspcafe.article.dao;
 import com.hyeonuk.jspcafe.article.domain.Article;
 import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -31,19 +28,23 @@ public class InMemoryArticleDao implements ArticleDao{
 
     @Override
     public List<Article> findAll() {
-        return new ArrayList<>(store.values());
+        return store.values()
+                .stream()
+                .filter(article->article.getDeletedAt() == null)
+                .toList();
     }
 
     @Override
     public Optional<Article> findById(Long id) {
         return store.values()
                 .stream()
-                .filter(article->article.getId().equals(id))
+                .filter(article->article.getId().equals(id) && article.getDeletedAt() == null)
                 .findFirst();
     }
 
     @Override
     public void deleteById(Long id) {
-        store.remove(id);
+        store.get(id)
+                .setDeletedAt(new Date());
     }
 }

--- a/src/main/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDao.java
@@ -113,7 +113,7 @@ public class MysqlArticleDao implements ArticleDao{
     @Override
     public void deleteById(Long id) {
         try(Connection conn = manager.getConnection()){
-            String sql = "update article set deletedAt = now() where id = ?";
+            String sql = "update article set deletedAt = now() where id = ? and deletedAt is null";
             PreparedStatement pstmt = conn.prepareStatement(sql);
             pstmt.setLong(1, id);
 

--- a/src/main/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDao.java
@@ -8,6 +8,7 @@ import com.hyeonuk.jspcafe.member.domain.Member;
 
 import java.sql.*;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -76,7 +77,8 @@ public class MysqlArticleDao implements ArticleDao{
     @Override
     public List<Article> findAll() {
         try(Connection conn = manager.getConnection()){
-            String sql = "select a.id as \"a.id\",a.title as \"a.title\", a.contents as \"a.contents\", m.id as \"m.id\",m.nickname as \"m.nickname\",m.password as \"m.password\",m.memberId as \"m.memberId\",m.email as \"m.email\" from article a left join member m on m.id = a.writer";
+            String sql = "select a.id as \"a.id\",a.title as \"a.title\", a.contents as \"a.contents\", a.deletedAt as \"a.deletedAt\", m.id as \"m.id\",m.nickname as \"m.nickname\",m.password as \"m.password\",m.memberId as \"m.memberId\",m.email as \"m.email\" " +
+                    "from article a left join member m on m.id = a.writer where a.deletedAt is null";
             PreparedStatement pstmt = conn.prepareStatement(sql);
             ResultSet rs = pstmt.executeQuery();
             List<Article> articles = new ArrayList<>();
@@ -93,7 +95,8 @@ public class MysqlArticleDao implements ArticleDao{
     @Override
     public Optional<Article> findById(Long id) {
         try(Connection conn = manager.getConnection()){
-            String sql = "select a.id as \"a.id\",a.title as \"a.title\", a.contents as \"a.contents\", m.id as \"m.id\",m.nickname as \"m.nickname\",m.password as \"m.password\",m.memberId as \"m.memberId\",m.email as \"m.email\" from article a left join member m on m.id = a.writer where a.id = ?";
+            String sql = "select a.id as \"a.id\",a.title as \"a.title\", a.contents as \"a.contents\", a.deletedAt as \"a.deletedAt\", m.id as \"m.id\",m.nickname as \"m.nickname\",m.password as \"m.password\",m.memberId as \"m.memberId\",m.email as \"m.email\" " +
+                    "from article a left join member m on m.id = a.writer where a.id = ? and a.deletedAt is null";
             PreparedStatement pstmt = conn.prepareStatement(sql);
             pstmt.setLong(1, id);
             ResultSet rs = pstmt.executeQuery();
@@ -110,7 +113,7 @@ public class MysqlArticleDao implements ArticleDao{
     @Override
     public void deleteById(Long id) {
         try(Connection conn = manager.getConnection()){
-            String sql = "delete from article where id = ?";
+            String sql = "update article set deletedAt = now() where id = ?";
             PreparedStatement pstmt = conn.prepareStatement(sql);
             pstmt.setLong(1, id);
 
@@ -124,6 +127,7 @@ public class MysqlArticleDao implements ArticleDao{
         Long id = rs.getLong("a.id");
         String title = rs.getString("a.title");
         String contents = rs.getString("a.contents");
+        Date deletedAt = rs.getDate("a.deletedAt");
 
         Long writerId = rs.getLong("m.id");
         String nickname = rs.getString("m.nickname");
@@ -131,6 +135,6 @@ public class MysqlArticleDao implements ArticleDao{
         String memberId = rs.getString("m.memberId");
         String email = rs.getString("m.email");
 
-        return new Article(id,new Member(writerId,memberId,password,nickname,email),title,contents);
+        return new Article(id,new Member(writerId,memberId,password,nickname,email),title,contents,deletedAt);
     }
 }

--- a/src/main/java/com/hyeonuk/jspcafe/article/domain/Article.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/domain/Article.java
@@ -2,11 +2,14 @@ package com.hyeonuk.jspcafe.article.domain;
 
 import com.hyeonuk.jspcafe.member.domain.Member;
 
+import java.util.Date;
+
 public class Article {
     private Long id;
     private Member writer;
     private String title;
     private String contents;
+    private Date deletedAt;
 
     public Article(Long id,Member writer,String title,String contents){
         this.id=id;
@@ -18,6 +21,13 @@ public class Article {
         this.writer = writer;
         this.title = title;
         this.contents = contents;
+    }
+    public Article(Long id, Member writer, String title, String contents, Date deletedAt) {
+        this.id = id;
+        this.writer = writer;
+        this.title = title;
+        this.contents = contents;
+        this.deletedAt = deletedAt;
     }
 
     public Long getId() {
@@ -50,6 +60,14 @@ public class Article {
 
     public void setContents(String contents) {
         this.contents = contents;
+    }
+
+    public Date getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(Date deletedAt) {
+        this.deletedAt = deletedAt;
     }
 
     public boolean validation(){

--- a/src/main/java/com/hyeonuk/jspcafe/article/domain/Article.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/domain/Article.java
@@ -1,18 +1,20 @@
 package com.hyeonuk.jspcafe.article.domain;
 
+import com.hyeonuk.jspcafe.member.domain.Member;
+
 public class Article {
     private Long id;
-    private String writer;
+    private Member writer;
     private String title;
     private String contents;
 
-    public Article(Long id,String writer,String title,String contents){
+    public Article(Long id,Member writer,String title,String contents){
         this.id=id;
         this.writer=writer;
         this.title = title;
         this.contents = contents;
     }
-    public Article(String writer, String title, String contents) {
+    public Article(Member writer, String title, String contents) {
         this.writer = writer;
         this.title = title;
         this.contents = contents;
@@ -26,11 +28,11 @@ public class Article {
         this.id = id;
     }
 
-    public String getWriter() {
+    public Member getWriter() {
         return writer;
     }
 
-    public void setWriter(String writer) {
+    public void setWriter(Member writer) {
         this.writer = writer;
     }
 
@@ -53,6 +55,6 @@ public class Article {
     public boolean validation(){
         return this.title != null && !this.title.isBlank()
                 && this.contents!=null && !this.contents.isBlank()
-                && this.writer != null && !this.writer.isBlank();
+                && this.writer != null && this.writer.getId() != null;
     }
 }

--- a/src/main/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServlet.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServlet.java
@@ -45,7 +45,7 @@ public class ArticleControlServlet extends HttpServlet {
             else if(pathParts.length == 3 && "form".equals(pathParts[2])){
                 HttpSession session = req.getSession();
                 Member member = (Member)session.getAttribute("member");
-                if(!article.getWriter().equals(member.getMemberId())) {
+                if(!article.getWriter().getId().equals(member.getId())) {
                     throw new HttpBadRequestException("작성자가 아닙니다.");
                 }
                 req.getRequestDispatcher("/templates/qna/modify.jsp").forward(req, resp);
@@ -71,7 +71,7 @@ public class ArticleControlServlet extends HttpServlet {
                     .orElseThrow(() -> new HttpNotFoundException(articleId + "번의 게시글을 찾을 수 없습니다."));
 
             Member member = (Member)req.getSession().getAttribute("member");
-            if(!article.getWriter().equals(member.getMemberId())) throw new HttpBadRequestException("작성자가 아니라 권한이 없습니다.");
+            if(!article.getWriter().getId().equals(member.getId())) throw new HttpBadRequestException("작성자가 아니라 권한이 없습니다.");
 
             String method = req.getParameter("_method");
             if("PUT".equalsIgnoreCase(method)){

--- a/src/main/java/com/hyeonuk/jspcafe/article/servlet/ArticleRegistServlet.java
+++ b/src/main/java/com/hyeonuk/jspcafe/article/servlet/ArticleRegistServlet.java
@@ -40,7 +40,7 @@ public class ArticleRegistServlet extends HttpServlet {
         String writer = member.getMemberId();
         String title = req.getParameter("title");
         String contents = req.getParameter("contents");
-        Article article = new Article(writer, title, contents);
+        Article article = new Article(member, title, contents);
 
         if(!article.validation()) throw new InvalidArticleRegistRequest("빈값이 존재하면 안됩니다.");
 

--- a/src/main/java/com/hyeonuk/jspcafe/global/servlet/MyServletContextListener.java
+++ b/src/main/java/com/hyeonuk/jspcafe/global/servlet/MyServletContextListener.java
@@ -10,6 +10,9 @@ import com.hyeonuk.jspcafe.global.utils.BcryptPasswordEncoder;
 import com.hyeonuk.jspcafe.global.utils.PasswordEncoder;
 import com.hyeonuk.jspcafe.member.dao.MemberDao;
 import com.hyeonuk.jspcafe.member.dao.MysqlMemberDao;
+import com.hyeonuk.jspcafe.reply.dao.MysqlReplyDao;
+import com.hyeonuk.jspcafe.reply.dao.ReplyDao;
+import com.hyeonuk.jspcafe.utils.ObjectMapper;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 
@@ -17,6 +20,8 @@ public class MyServletContextListener implements ServletContextListener{
     private MemberDao memberDao;
     private PasswordEncoder passwordEncoder;
     private ArticleDao articleDao;
+    private ReplyDao replyDao;
+    private ObjectMapper objectMapper;
     @Override
     public void contextInitialized(ServletContextEvent sce) {
         ServletContextListener.super.contextInitialized(sce);
@@ -26,9 +31,13 @@ public class MyServletContextListener implements ServletContextListener{
             memberDao = new MysqlMemberDao(dbManager);
             passwordEncoder = new BcryptPasswordEncoder();
             articleDao = new MysqlArticleDao(dbManager);
+            replyDao = new MysqlReplyDao(dbManager);
+            objectMapper = new ObjectMapper();
             sce.getServletContext().setAttribute("memberDao", memberDao);
             sce.getServletContext().setAttribute("passwordEncoder", passwordEncoder);
             sce.getServletContext().setAttribute("articleDao", articleDao);
+            sce.getServletContext().setAttribute("replyDao", replyDao);
+            sce.getServletContext().setAttribute("objectMapper", objectMapper);
         } catch (Exception e) {
             throw new HttpInternalServerErrorException("서버에러입니다.");
         }

--- a/src/main/java/com/hyeonuk/jspcafe/member/servlets/MemberControlServlet.java
+++ b/src/main/java/com/hyeonuk/jspcafe/member/servlets/MemberControlServlet.java
@@ -82,7 +82,7 @@ public class MemberControlServlet extends HttpServlet {
         if(!newMember.validation()) throw new InvalidMemberRegistRequest("값을 확인해주세요");
 
         memberDao.save(newMember);
-
+        req.getSession().setAttribute("member", newMember);//새로운 값으로 session update
         resp.sendRedirect("/members/"+newMember.getMemberId());
     }
 

--- a/src/main/java/com/hyeonuk/jspcafe/reply/dao/InMemoryReplyDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/reply/dao/InMemoryReplyDao.java
@@ -1,0 +1,54 @@
+package com.hyeonuk.jspcafe.reply.dao;
+
+import com.hyeonuk.jspcafe.reply.domain.Reply;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+public class InMemoryReplyDao implements ReplyDao {
+    private final Map<Long, Reply> replies = new HashMap<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+
+    @Override
+    public Reply save(Reply reply) {
+        if (reply.getId() == null) { // 새로운 저장
+            reply.setId(idGenerator.getAndIncrement());
+            replies.put(reply.getId(), reply);
+        } else { // 기존의 Reply 업데이트
+            replies.put(reply.getId(), reply);
+        }
+        return reply;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        Reply reply = replies.get(id);
+        if (reply != null) {
+            reply.setDeletedAt(new Date()); // 실제로 삭제하지 않고, 삭제된 날짜만 설정
+        }
+    }
+
+    @Override
+    public void deleteAllByArticleId(Long articleId) {
+        replies.values().stream()
+                .filter(reply -> reply.getArticle().getId().equals(articleId))
+                .forEach(reply -> reply.setDeletedAt(new Date())); // 삭제된 날짜 설정
+    }
+
+    @Override
+    public List<Reply> findAllByArticleId(Long articleId) {
+        return replies.values().stream()
+                .filter(reply -> reply.getArticle().getId().equals(articleId) && reply.getDeletedAt() == null)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Reply> findById(Long id) {
+        Reply reply = replies.get(id);
+        if (reply != null && reply.getDeletedAt() == null) {
+            return Optional.of(reply);
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/hyeonuk/jspcafe/reply/dao/MysqlReplyDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/reply/dao/MysqlReplyDao.java
@@ -96,10 +96,11 @@ public class MysqlReplyDao implements ReplyDao{
     @Override
     public List<Reply> findAllByArticleId(Long articleId) {
         try(Connection conn = manager.getConnection()){
-            String sql = "select r.id as 'r.id',r.articleId as 'r.article',r.contents as 'r.contents'," +
-                    "m.id as 'm.id', m.nickname as 'm.nickname', m.email as 'm.email', m.memberId as 'm.memberId' " +
-                    "from reply r left join member m on m.id = r.memberId";
+            String sql = "select r.id as \"r.id\",r.articleId as \"r.articleId\",r.contents as \"r.contents\", " +
+                    "m.id as \"m.id\", m.nickname as \"m.nickname\", m.email as \"m.email\", m.memberId as \"m.memberId\" " +
+                    "from reply r left join member m on r.memberId = m.id where r.articleId = ?";
             PreparedStatement pstmt = conn.prepareStatement(sql);
+            pstmt.setLong(1, articleId);
             ResultSet rs = pstmt.executeQuery();
             List<Reply> replies = new ArrayList<>();
             while(rs.next()){
@@ -114,8 +115,8 @@ public class MysqlReplyDao implements ReplyDao{
     @Override
     public Optional<Reply> findById(Long id) {
         try(Connection conn = manager.getConnection()){
-            String sql = "select r.id as 'r.id',r.articleId as 'r.article',r.contents as 'r.contents'," +
-                    "m.id as 'm.id', m.nickname as 'm.nickname', m.email as 'm.email', m.memberId as 'm.memberId' " +
+            String sql = "select r.id as \"r.id\",r.articleId as \"r.articleId\",r.contents as \"r.contents\"," +
+                    "m.id as \"m.id\", m.nickname as \"m.nickname\", m.email as \"m.email\", m.memberId as \"m.memberId\" " +
                     "from reply r left join member m on m.id = r.memberId where r.id = ?";
             PreparedStatement pstmt = conn.prepareStatement(sql);
             pstmt.setLong(1, id);

--- a/src/main/java/com/hyeonuk/jspcafe/reply/dao/MysqlReplyDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/reply/dao/MysqlReplyDao.java
@@ -72,7 +72,7 @@ public class MysqlReplyDao implements ReplyDao{
     @Override
     public void deleteById(Long id) {
         try(Connection conn = manager.getConnection()){
-            String sql = "delete from reply where id = ?";
+            String sql = "update reply set deletedAt = now() where id = ?";
             PreparedStatement pstmt = conn.prepareStatement(sql);
             pstmt.setLong(1, id);
             pstmt.executeUpdate();
@@ -84,7 +84,7 @@ public class MysqlReplyDao implements ReplyDao{
     @Override
     public void deleteAllByArticleId(Long articleId) {
         try(Connection conn = manager.getConnection()){
-            String sql = "delete from reply where articleId = ?";
+            String sql = "update reply set deletedAt = now() where articleId = ?";
             PreparedStatement pstmt = conn.prepareStatement(sql);
             pstmt.setLong(1, articleId);
             pstmt.executeUpdate();
@@ -96,9 +96,9 @@ public class MysqlReplyDao implements ReplyDao{
     @Override
     public List<Reply> findAllByArticleId(Long articleId) {
         try(Connection conn = manager.getConnection()){
-            String sql = "select r.id as \"r.id\",r.articleId as \"r.articleId\",r.contents as \"r.contents\", " +
+            String sql = "select r.id as \"r.id\",r.articleId as \"r.articleId\",r.contents as \"r.contents\",  " +
                     "m.id as \"m.id\", m.nickname as \"m.nickname\", m.email as \"m.email\", m.memberId as \"m.memberId\" " +
-                    "from reply r left join member m on r.memberId = m.id where r.articleId = ?";
+                    "from reply r left join member m on r.memberId = m.id where r.articleId = ? and r.deletedAt is null";
             PreparedStatement pstmt = conn.prepareStatement(sql);
             pstmt.setLong(1, articleId);
             ResultSet rs = pstmt.executeQuery();
@@ -117,7 +117,7 @@ public class MysqlReplyDao implements ReplyDao{
         try(Connection conn = manager.getConnection()){
             String sql = "select r.id as \"r.id\",r.articleId as \"r.articleId\",r.contents as \"r.contents\"," +
                     "m.id as \"m.id\", m.nickname as \"m.nickname\", m.email as \"m.email\", m.memberId as \"m.memberId\" " +
-                    "from reply r left join member m on m.id = r.memberId where r.id = ?";
+                    "from reply r left join member m on m.id = r.memberId where r.id = ? and r.deletedAt is null";
             PreparedStatement pstmt = conn.prepareStatement(sql);
             pstmt.setLong(1, id);
             ResultSet rs = pstmt.executeQuery();

--- a/src/main/java/com/hyeonuk/jspcafe/reply/dao/MysqlReplyDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/reply/dao/MysqlReplyDao.java
@@ -1,0 +1,145 @@
+package com.hyeonuk.jspcafe.reply.dao;
+
+import com.hyeonuk.jspcafe.article.domain.Article;
+import com.hyeonuk.jspcafe.global.db.DBManager;
+import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
+import com.hyeonuk.jspcafe.global.exception.HttpInternalServerErrorException;
+import com.hyeonuk.jspcafe.member.domain.Member;
+import com.hyeonuk.jspcafe.reply.domain.Reply;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class MysqlReplyDao implements ReplyDao{
+    private DBManager manager;
+    public MysqlReplyDao(DBManager manager) {
+        this.manager = manager;
+    }
+
+    @Override
+    public Reply save(Reply reply) {
+        try(Connection conn = manager.getConnection()) {
+            if(reply.getId() == null){//save작업
+                Long articleId = reply.getArticle().getId();
+                Long memberId = reply.getMember().getId();
+                String contents = reply.getContents();
+
+                String query = "insert into reply(memberId,articleId,contents) values(?,?,?)";
+                PreparedStatement pstmt = conn.prepareStatement(query, Statement.RETURN_GENERATED_KEYS);
+                pstmt.setLong(1, memberId);
+                pstmt.setLong(2, articleId);
+                pstmt.setString(3, contents);
+                int num = pstmt.executeUpdate();
+
+                ResultSet rs = pstmt.getGeneratedKeys();
+                if(rs.next()){
+                    reply.setId(rs.getLong(1));
+                }
+            }
+            else{//update 작업
+                Long id = reply.getId();
+                String contents = reply.getContents();
+                Optional<Reply> byId = findById(id);
+
+                if(byId.isPresent()) {
+                    String query = "update reply set contents = ? where id = ?";
+                    PreparedStatement pstmt = conn.prepareStatement(query);
+                    pstmt.setString(1,contents);
+                    pstmt.setLong(2, id);
+                    pstmt.executeUpdate();
+                }
+                else{
+                    Long memberId = reply.getMember().getId();
+                    Long articleId = reply.getArticle().getId();
+                    String query = "insert into reply(id,memberId,articleId,contents) values(?,?,?,?)";
+                    PreparedStatement pstmt = conn.prepareStatement(query, Statement.RETURN_GENERATED_KEYS);
+                    pstmt.setLong(1,id);
+                    pstmt.setLong(2,memberId);
+                    pstmt.setLong(3,articleId);
+                    pstmt.setString(4,contents);
+
+                    pstmt.executeUpdate();
+                }
+            }
+            return reply;
+        }catch(SQLException e) {
+            throw new HttpInternalServerErrorException("error");
+        }
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        try(Connection conn = manager.getConnection()){
+            String sql = "delete from reply where id = ?";
+            PreparedStatement pstmt = conn.prepareStatement(sql);
+            pstmt.setLong(1, id);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new DataIntegrityViolationException("error");
+        }
+    }
+
+    @Override
+    public void deleteAllByArticleId(Long articleId) {
+        try(Connection conn = manager.getConnection()){
+            String sql = "delete from reply where articleId = ?";
+            PreparedStatement pstmt = conn.prepareStatement(sql);
+            pstmt.setLong(1, articleId);
+            pstmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new DataIntegrityViolationException("error");
+        }
+    }
+
+    @Override
+    public List<Reply> findAllByArticleId(Long articleId) {
+        try(Connection conn = manager.getConnection()){
+            String sql = "select r.id as 'r.id',r.articleId as 'r.article',r.contents as 'r.contents'," +
+                    "m.id as 'm.id', m.nickname as 'm.nickname', m.email as 'm.email', m.memberId as 'm.memberId' " +
+                    "from reply r left join member m on m.id = r.memberId";
+            PreparedStatement pstmt = conn.prepareStatement(sql);
+            ResultSet rs = pstmt.executeQuery();
+            List<Reply> replies = new ArrayList<>();
+            while(rs.next()){
+                replies.add(mappingReply(rs));
+            }
+            return replies;
+        } catch (SQLException e) {
+            throw new DataIntegrityViolationException("error");
+        }
+    }
+
+    @Override
+    public Optional<Reply> findById(Long id) {
+        try(Connection conn = manager.getConnection()){
+            String sql = "select r.id as 'r.id',r.articleId as 'r.article',r.contents as 'r.contents'," +
+                    "m.id as 'm.id', m.nickname as 'm.nickname', m.email as 'm.email', m.memberId as 'm.memberId' " +
+                    "from reply r left join member m on m.id = r.memberId where r.id = ?";
+            PreparedStatement pstmt = conn.prepareStatement(sql);
+            pstmt.setLong(1, id);
+            ResultSet rs = pstmt.executeQuery();
+            Reply reply = null;
+            if(rs.next()) {
+                reply = mappingReply(rs);
+            }
+            return Optional.ofNullable(reply);
+        } catch (SQLException e) {
+            throw new DataIntegrityViolationException("error");
+        }
+    }
+
+    private Reply mappingReply(ResultSet rs) throws SQLException {
+        Long replyId = rs.getLong("r.id");
+        Long articleId = rs.getLong("r.articleId");
+        String contents = rs.getString("r.contents");
+        Long mId = rs.getLong("m.id");
+        String nickname = rs.getString("m.nickname");
+        String email = rs.getString("m.email");
+        String memberId = rs.getString("m.memberId");
+        Member member = new Member(mId,memberId,"",nickname,email);
+        Reply reply = new Reply(replyId,new Article(articleId,null,"",""),member,contents);
+        return reply;
+    }
+}

--- a/src/main/java/com/hyeonuk/jspcafe/reply/dao/MysqlReplyDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/reply/dao/MysqlReplyDao.java
@@ -72,7 +72,7 @@ public class MysqlReplyDao implements ReplyDao{
     @Override
     public void deleteById(Long id) {
         try(Connection conn = manager.getConnection()){
-            String sql = "update reply set deletedAt = now() where id = ?";
+            String sql = "update reply set deletedAt = now() where id = ? and deletedAt is null";
             PreparedStatement pstmt = conn.prepareStatement(sql);
             pstmt.setLong(1, id);
             pstmt.executeUpdate();
@@ -84,7 +84,7 @@ public class MysqlReplyDao implements ReplyDao{
     @Override
     public void deleteAllByArticleId(Long articleId) {
         try(Connection conn = manager.getConnection()){
-            String sql = "update reply set deletedAt = now() where articleId = ?";
+            String sql = "update reply set deletedAt = now() where articleId = ? and deletedAt is null";
             PreparedStatement pstmt = conn.prepareStatement(sql);
             pstmt.setLong(1, articleId);
             pstmt.executeUpdate();

--- a/src/main/java/com/hyeonuk/jspcafe/reply/dao/ReplyDao.java
+++ b/src/main/java/com/hyeonuk/jspcafe/reply/dao/ReplyDao.java
@@ -1,0 +1,14 @@
+package com.hyeonuk.jspcafe.reply.dao;
+
+import com.hyeonuk.jspcafe.reply.domain.Reply;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReplyDao {
+    Reply save(Reply reply);
+    void deleteById(Long id);
+    void deleteAllByArticleId(Long articleId);
+    Optional<Reply> findById(Long id);
+    List<Reply> findAllByArticleId(Long articleId);
+}

--- a/src/main/java/com/hyeonuk/jspcafe/reply/domain/Reply.java
+++ b/src/main/java/com/hyeonuk/jspcafe/reply/domain/Reply.java
@@ -3,12 +3,22 @@ package com.hyeonuk.jspcafe.reply.domain;
 import com.hyeonuk.jspcafe.article.domain.Article;
 import com.hyeonuk.jspcafe.member.domain.Member;
 
+import java.util.Date;
+
 public class Reply {
     private Long id;
     private Article article;
     private Member member;
     private String contents;
+    private Date deletedAt;
 
+    public Reply(Long id,Article article,Member member,String contents,Date deletedAt){
+        this.id = id;
+        this.article = article;
+        this.member = member;
+        this.contents = contents;
+        this.deletedAt = deletedAt;
+    }
     public Reply(Long id, Article article, Member member, String contents) {
         this.id = id;
         this.article = article;
@@ -56,5 +66,13 @@ public class Reply {
 
     public void setContents(String contents) {
         this.contents = contents;
+    }
+
+    public Date getDeletedAt() {
+        return deletedAt;
+    }
+
+    public void setDeletedAt(Date deletedAt) {
+        this.deletedAt = deletedAt;
     }
 }

--- a/src/main/java/com/hyeonuk/jspcafe/reply/domain/Reply.java
+++ b/src/main/java/com/hyeonuk/jspcafe/reply/domain/Reply.java
@@ -1,0 +1,60 @@
+package com.hyeonuk.jspcafe.reply.domain;
+
+import com.hyeonuk.jspcafe.article.domain.Article;
+import com.hyeonuk.jspcafe.member.domain.Member;
+
+public class Reply {
+    private Long id;
+    private Article article;
+    private Member member;
+    private String contents;
+
+    public Reply(Long id, Article article, Member member, String contents) {
+        this.id = id;
+        this.article = article;
+        this.member = member;
+        this.contents = contents;
+    }
+    public Reply(Article article,Member member, String contents) {
+        this(null,article,member,contents);
+    }
+
+    public boolean validation(){
+        return this.id != null
+                && this.article != null && this.article.getId() != null
+                && this.member!= null && this.member.getId() != null
+                && this.contents!=null && !this.contents.isBlank();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Article getArticle() {
+        return article;
+    }
+
+    public void setArticle(Article article) {
+        this.article = article;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+
+    public void setContents(String contents) {
+        this.contents = contents;
+    }
+}

--- a/src/main/java/com/hyeonuk/jspcafe/reply/dto/ReplyDto.java
+++ b/src/main/java/com/hyeonuk/jspcafe/reply/dto/ReplyDto.java
@@ -1,0 +1,65 @@
+package com.hyeonuk.jspcafe.reply.dto;
+
+import com.hyeonuk.jspcafe.reply.domain.Reply;
+
+public class ReplyDto {
+    private Long replyId;
+    private Long memberId;
+    private String memberNickname;
+    private Long articleId;
+    private String contents;
+
+    public ReplyDto(){}
+
+    public ReplyDto(Long replyId, Long memberId,String memberNickname, Long articleId, String contents) {
+        this.replyId = replyId;
+        this.memberId = memberId;
+        this.articleId = articleId;
+        this.contents = contents;
+        this.memberNickname = memberNickname;
+    }
+
+    public static ReplyDto from(Reply reply) {
+        return new ReplyDto(reply.getId(),reply.getMember().getId(),reply.getMember().getNickname(),reply.getArticle().getId(),reply.getContents());
+    }
+
+    public Long getArticleId() {
+        return articleId;
+    }
+
+    public void setArticleId(Long articleId) {
+        this.articleId = articleId;
+    }
+
+    public Long getReplyId() {
+        return replyId;
+    }
+
+    public void setReplyId(Long replyId) {
+        this.replyId = replyId;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(Long memberId) {
+        this.memberId = memberId;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+
+    public void setContents(String contents) {
+        this.contents = contents;
+    }
+
+    public String getMemberNickname() {
+        return memberNickname;
+    }
+
+    public void setMemberNickname(String memberNickname) {
+        this.memberNickname = memberNickname;
+    }
+}

--- a/src/main/java/com/hyeonuk/jspcafe/reply/servlet/ReplyControlServlet.java
+++ b/src/main/java/com/hyeonuk/jspcafe/reply/servlet/ReplyControlServlet.java
@@ -1,0 +1,147 @@
+package com.hyeonuk.jspcafe.reply.servlet;
+
+import com.hyeonuk.jspcafe.article.dao.ArticleDao;
+import com.hyeonuk.jspcafe.article.domain.Article;
+import com.hyeonuk.jspcafe.global.exception.HttpBadRequestException;
+import com.hyeonuk.jspcafe.global.exception.HttpNotFoundException;
+import com.hyeonuk.jspcafe.member.domain.Member;
+import com.hyeonuk.jspcafe.reply.dao.ReplyDao;
+import com.hyeonuk.jspcafe.reply.domain.Reply;
+import com.hyeonuk.jspcafe.reply.dto.ReplyDto;
+import com.hyeonuk.jspcafe.utils.ObjectMapper;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ReplyControlServlet extends HttpServlet {
+    private ReplyDao replyDao;
+    private ArticleDao articleDao;
+    private ObjectMapper objectMapper;
+    @Override
+    public void init(ServletConfig config) throws ServletException {
+        super.init(config);
+        replyDao = (ReplyDao) config.getServletContext().getAttribute("replyDao");
+        articleDao = (ArticleDao) config.getServletContext().getAttribute("articleDao");
+        objectMapper = (ObjectMapper) config.getServletContext().getAttribute("objectMapper");
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try{
+            String pathInfo = req.getPathInfo();
+            if(pathInfo == null || "/".equals(pathInfo)) {
+                throw new HttpBadRequestException("잘못된 요청입니다.");
+            }
+            String[] pathParts = pathInfo.split("/");
+            if(pathParts.length < 2){
+                throw new HttpBadRequestException("잘못된 요청입니다.");
+            }
+            Long articleId = Long.parseLong(pathParts[1]);
+            Article article = articleDao.findById(articleId)
+                    .orElseThrow(() -> new HttpNotFoundException("게시글을 찾을 수 없습니다."));
+
+            List<ReplyDto> replies = replyDao.findAllByArticleId(article.getId())
+                    .stream()
+                    .map(ReplyDto::from)
+                    .collect(Collectors.toList());
+
+            resp.setCharacterEncoding("UTF-8");
+            resp.setContentType("application/json");
+            resp.getWriter().write(objectMapper.toJson(replies));
+            resp.getWriter().flush();
+        }catch(NumberFormatException e){
+            throw new HttpBadRequestException("잘못된 요청입니다.");
+        }
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            Member member = (Member) req.getSession().getAttribute("member");
+            //등록
+            String reqBody = new String(req.getInputStream().readAllBytes());
+            ReplyDto request = objectMapper.fromJson(reqBody, ReplyDto.class);
+
+            String contents = request.getContents();
+            Long articleId = request.getArticleId();
+            Reply reply = new Reply(new Article(articleId, null, null, null),
+                    member, contents);
+
+            replyDao.save(reply);
+            resp.setCharacterEncoding("UTF-8");
+            resp.setContentType("application/json");
+            resp.getWriter().write(objectMapper.toJson(ReplyDto.from(reply)));
+            resp.getWriter().flush();
+
+        }catch(HttpBadRequestException e){
+            String message = e.getMessage();
+            Map<String,String> ret = Map.of("message",message);
+            resp.setCharacterEncoding("UTF-8");
+            resp.setContentType("application/json");
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            resp.getWriter().write(objectMapper.toJson(ret));
+            resp.getWriter().flush();
+        }catch (Exception e){
+            Map<String,String> ret = Map.of("message","서버 내부 에러입니다.");
+            resp.setCharacterEncoding("UTF-8");
+            resp.setContentType("application/json");
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            resp.getWriter().write(objectMapper.toJson(ret));
+            resp.getWriter().flush();
+        }
+    }
+
+    @Override
+    protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try {
+            Member member = (Member) req.getSession().getAttribute("member");
+            //삭제
+            String pathInfo = req.getPathInfo();
+            if(pathInfo == null || "/".equals(pathInfo)) {
+                throw new HttpBadRequestException("잘못된 요청입니다.");
+            }
+            String[] pathParts = pathInfo.split("/");
+            if(pathParts.length < 2){
+                throw new HttpBadRequestException("잘못된 요청입니다.");
+            }
+            Long replyId = Long.parseLong(pathParts[1]);
+
+            Reply reply = replyDao.findById(replyId)
+                    .orElseThrow(() -> new HttpBadRequestException("reply가 없습니다."));
+
+            if(reply.getMember().getId() != member.getId()){
+                throw new HttpBadRequestException("자신의 댓글이 아닙니다.");
+            }
+
+            replyDao.deleteById(reply.getId());
+            resp.setCharacterEncoding("UTF-8");
+            resp.setContentType("application/json");
+            resp.getWriter().write(objectMapper.toJson(new HashMap<>()));
+        }catch(HttpBadRequestException e){
+            e.printStackTrace();
+            String message = e.getMessage();
+            Map<String,String> ret = Map.of("message",message);
+            resp.setCharacterEncoding("UTF-8");
+            resp.setContentType("application/json");
+            resp.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            resp.getWriter().write(objectMapper.toJson(ret));
+            resp.getWriter().flush();
+        }catch (Exception e){
+            e.printStackTrace();
+            Map<String,String> ret = Map.of("message","서버 내부 에러입니다.");
+            resp.setCharacterEncoding("UTF-8");
+            resp.setContentType("application/json");
+            resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            resp.getWriter().write(objectMapper.toJson(ret));
+            resp.getWriter().flush();
+        }
+    }
+}

--- a/src/main/java/com/hyeonuk/jspcafe/reply/servlet/ReplyControlServlet.java
+++ b/src/main/java/com/hyeonuk/jspcafe/reply/servlet/ReplyControlServlet.java
@@ -126,7 +126,6 @@ public class ReplyControlServlet extends HttpServlet {
             resp.setContentType("application/json");
             resp.getWriter().write(objectMapper.toJson(new HashMap<>()));
         }catch(HttpBadRequestException e){
-            e.printStackTrace();
             String message = e.getMessage();
             Map<String,String> ret = Map.of("message",message);
             resp.setCharacterEncoding("UTF-8");
@@ -135,7 +134,6 @@ public class ReplyControlServlet extends HttpServlet {
             resp.getWriter().write(objectMapper.toJson(ret));
             resp.getWriter().flush();
         }catch (Exception e){
-            e.printStackTrace();
             Map<String,String> ret = Map.of("message","서버 내부 에러입니다.");
             resp.setCharacterEncoding("UTF-8");
             resp.setContentType("application/json");

--- a/src/main/java/com/hyeonuk/jspcafe/utils/ObjectMapper.java
+++ b/src/main/java/com/hyeonuk/jspcafe/utils/ObjectMapper.java
@@ -1,0 +1,173 @@
+package com.hyeonuk.jspcafe.utils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.Map;
+
+public class ObjectMapper {
+
+    private Object castValue(String value,Class<?> type){
+        if(Integer.class.equals(type) || int.class.equals(type)){
+            return Integer.parseInt(value);
+        }
+        if(Long.class.equals(type) || long.class.equals(type)){
+            return Long.parseLong(value);
+        }
+        if(Double.class.equals(type) || double.class.equals(type)){
+            return Double.parseDouble(value);
+        }
+        if(Float.class.equals(type) || float.class.equals(type)){
+            return Float.parseFloat(value);
+        }
+        if(Boolean.class.equals(type) || boolean.class.equals(type)){
+            return Boolean.parseBoolean(value);
+        }
+        if(String.class.equals(type)){
+            return value;
+        }
+        return null;
+    }
+
+    public <T> T fromJson(String json,Class<T> clazz){
+        try {
+            //일단 1 depth만 구현
+            Constructor<T> defaultConstructor = clazz.getDeclaredConstructor();
+            defaultConstructor.setAccessible(true);
+            T obj = defaultConstructor.newInstance();
+            String withoutBrackets = json.substring(1, json.length() - 1);
+            String[] keyValuePairs = withoutBrackets.split(",");
+            for(String keyValuePair : keyValuePairs){
+                String[] keyValue = keyValuePair.split(":");
+                if(keyValue.length == 2){
+                    String key = keyValue[0].trim().replaceAll("\"","").replaceAll("'","");
+                    String value = keyValue[1].trim().replaceAll("\"","").replaceAll("'","");
+                    Field field = clazz.getDeclaredField(key);
+                    Class<?> type = field.getType();
+                    field.setAccessible(true);
+                    field.set(obj, castValue(value,type));
+                }
+            }
+            return obj;
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException(clazz.getName()+" does not have a no-arg constructor");
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchFieldException e) {
+            throw new IllegalArgumentException("bad request");
+        }
+    }
+
+    public String toJson(Object obj) {
+        if (obj == null) {
+            return "null";
+        }
+
+        if (obj instanceof Number || obj instanceof Boolean) {
+            return obj.toString();
+        }
+
+        if (obj instanceof String) {
+            return "\"" + escapeString((String) obj) + "\"";
+        }
+
+        if (obj.getClass().isArray() || obj instanceof Collection) {
+            return arrayToJson(obj);
+        }
+
+        if (obj instanceof Map) {
+            return mapToJson((Map<?, ?>) obj);
+        }
+
+        return objectToJson(obj);
+    }
+
+    private String objectToJson(Object obj) {
+        StringBuilder sb = new StringBuilder("{");
+        Field[] fields = obj.getClass().getDeclaredFields();
+        for (int i = 0; i < fields.length; i++) {
+            Field field = fields[i];
+            field.setAccessible(true);
+
+            try {
+                String fieldName = field.getName();
+                Object value = field.get(obj);
+
+                sb.append("\"").append(fieldName).append("\":");
+                sb.append(toJson(value));
+
+                if (i < fields.length - 1) {
+                    sb.append(",");
+                }
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        }
+
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String arrayToJson(Object obj) {
+        StringBuilder sb = new StringBuilder("[");
+
+        if (obj.getClass().isArray()) {
+            Object[] array = toObjectArray(obj);
+            for (int i = 0; i < array.length; i++) {
+                sb.append(toJson(array[i]));
+                if (i < array.length - 1) {
+                    sb.append(",");
+                }
+            }
+        } else if (obj instanceof Collection) {
+            Collection<?> collection = (Collection<?>) obj;
+            int i = 0;
+            for (Object item : collection) {
+                sb.append(toJson(item));
+                if (i < collection.size() - 1) {
+                    sb.append(",");
+                }
+                i++;
+            }
+        }
+
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private String mapToJson(Map<?, ?> map) {
+        StringBuilder sb = new StringBuilder("{");
+        int i = 0;
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            sb.append(toJson(entry.getKey())).append(":");
+            sb.append(toJson(entry.getValue()));
+            if (i < map.size() - 1) {
+                sb.append(",");
+            }
+            i++;
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String escapeString(String str) {
+        return str.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\b", "\\b")
+                .replace("\f", "\\f")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+
+    private Object[] toObjectArray(Object array) {
+        if (array instanceof Object[]) {
+            return (Object[]) array;
+        }
+        int length = java.lang.reflect.Array.getLength(array);
+        Object[] result = new Object[length];
+        for (int i = 0; i < length; i++) {
+            result[i] = java.lang.reflect.Array.get(array, i);
+        }
+        return result;
+    }
+}

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -22,12 +22,14 @@ CREATE TABLE article (
                          id BIGINT PRIMARY KEY AUTO_INCREMENT,
                          title VARCHAR(255) NOT NULL,
                          writer BIGINT NOT NULL,
-                         contents TEXT NOT NULL
+                         contents TEXT NOT NULL,
+                         deletedAt DATETIME DEFAULT NULL
 );
 
 CREATE TABLE reply (
                     id BIGINT PRIMARY KEY AUTO_INCREMENT,
                     articleId BIGINT NOT NULL,
                     memberId BIGINT NOT NULL,
-                    contents TEXT NOT NULL
+                    contents TEXT NOT NULL,
+                    deletedAt DATETIME DEFAULT NULL
 );

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -6,6 +6,7 @@ USE cafe;
 -- 기존 테이블이 존재한다면 삭제
 DROP TABLE IF EXISTS article;
 DROP TABLE IF EXISTS member;
+DROP TABLE IF EXISTS reply;
 
 -- member 테이블 생성
 CREATE TABLE member (
@@ -22,4 +23,11 @@ CREATE TABLE article (
                          title VARCHAR(255) NOT NULL,
                          writer BIGINT NOT NULL,
                          contents TEXT NOT NULL
+);
+
+CREATE TABLE reply (
+                    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                    articleId BIGINT NOT NULL,
+                    memberId BIGINT NOT NULL,
+                    contents TEXT NOT NULL
 );

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -20,6 +20,6 @@ CREATE TABLE member (
 CREATE TABLE article (
                          id BIGINT PRIMARY KEY AUTO_INCREMENT,
                          title VARCHAR(255) NOT NULL,
-                         writer VARCHAR(255) NOT NULL,
+                         writer BIGINT NOT NULL,
                          contents TEXT NOT NULL
 );

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -72,6 +72,15 @@
         <servlet-name>articleListServlet</servlet-name>
         <url-pattern></url-pattern>
     </servlet-mapping>
+    
+    <servlet>
+        <servlet-name>replyControlServlet</servlet-name>
+        <servlet-class>com.hyeonuk.jspcafe.reply.servlet.ReplyControlServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>replyControlServlet</servlet-name>
+        <url-pattern>/replies/*</url-pattern>
+    </servlet-mapping>
 
     <filter>
         <filter-name>sessionFilter</filter-name>
@@ -81,6 +90,7 @@
         <filter-name>sessionFilter</filter-name>
         <url-pattern>/members/*/form</url-pattern>
         <url-pattern>/questions/*</url-pattern>
+        <url-pattern>/replies/*</url-pattern>
     </filter-mapping>
 
     <filter>

--- a/src/main/webapp/qnaList.jsp
+++ b/src/main/webapp/qnaList.jsp
@@ -22,7 +22,7 @@
                           <div class="auth-info">
                               <i class="icon-add-comment"></i>
                               <span class="time">2016-01-15 18:47</span>
-                              <a href="${pageContext.request.contextPath}/members/<%=article.getWriter()%>" class="author"><%=article.getWriter()%></a>
+                              <a href="${pageContext.request.contextPath}/members/<%=article.getWriter().getMemberId()%>" class="author"><%=article.getWriter().getNickname()%></a>
                           </div>
 <%--                          <div class="reply" title="댓글">--%>
 <%--                              <i class="icon-reply"></i>--%>

--- a/src/main/webapp/templates/component/header.jsp
+++ b/src/main/webapp/templates/component/header.jsp
@@ -94,5 +94,50 @@
 <script src="${pageContext.request.contextPath}/templates/js/jquery-2.2.0.min.js"></script>
 <script src="${pageContext.request.contextPath}/templates/js/bootstrap.min.js"></script>
 <script src="${pageContext.request.contextPath}/templates/js/scripts.js"></script>
+<script>
+    // 공통된 설정을 포함한 fetch 함수
+    async function fetchWrapper(url, options) {
+        try {
+            const response = await fetch(url, options);
+            if (!response.ok) {
+                // 서버 응답이 성공적이지 않다면 에러를 던짐
+                const errorResponse = await response.json();
+                throw new Error(errorResponse);
+            }
+            // 응답이 비어있지 않다면 JSON을 반환
+            return response.json();
+        } catch (error) {
+            console.error('Fetch error:', error);
+            throw error;
+        }
+    }
+
+    async function get(endpoint) {
+        return fetchWrapper(endpoint, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    }
+    async function post(endpoint, data) {
+        return fetchWrapper(endpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(data),
+        });
+    }
+    async function del(endpoint) {
+        return fetchWrapper(endpoint, {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    }
+
+</script>
 </body>
 </html>

--- a/src/main/webapp/templates/component/header.jsp
+++ b/src/main/webapp/templates/component/header.jsp
@@ -76,6 +76,9 @@
                         Member member = (Member)session.getAttribute("member");
                 %>
                 <li>
+                    <h1><%=member.getNickname()%></h1>
+                </li>
+                <li>
                     <form method="post" action="${pageContext.request.contextPath}/logout">
                         <button type="submit">로그아웃</button>
                     </form>

--- a/src/main/webapp/templates/qna/show.jsp
+++ b/src/main/webapp/templates/qna/show.jsp
@@ -56,10 +56,8 @@
               </article>
 
               <div class="qna-comment">
-<%--                  <div class="qna-comment-slipp">--%>
-<%--                      <p class="qna-comment-count"><strong>2</strong>개의 의견</p>--%>
-<%--                      <div class="qna-comment-slipp-articles">--%>
-
+                  <div class="qna-comment-slipp">
+                      <div id="comment-box" class="qna-comment-slipp-articles">
 <%--                          <article class="article" id="answer-1405">--%>
 <%--                              <div class="article-header">--%>
 <%--                                  <div class="article-header-thumb">--%>
@@ -118,49 +116,170 @@
 <%--                                  </ul>--%>
 <%--                              </div>--%>
 <%--                          </article>--%>
-<%--                          <form class="submit-write">--%>
-<%--                              <div class="form-group" style="padding:14px;">--%>
-<%--                                  <textarea class="form-control" placeholder="Update your status"></textarea>--%>
-<%--                              </div>--%>
-<%--                              <button class="btn btn-success pull-right" type="button">답변하기</button>--%>
-<%--                              <div class="clearfix" />--%>
-<%--                          </form>--%>
-<%--                      </div>--%>
-<%--                  </div>--%>
+                          <form class="submit-write">
+                              <div class="form-group" style="padding:14px;">
+                                  <textarea class="form-control" placeholder="Update your status" id="replyContents"></textarea>
+                              </div>
+                              <button class="btn btn-success pull-right" id="replyPostBtn" type="button">답변하기</button>
+                              <div class="clearfix" />
+                          </form>
+                      </div>
+                  </div>
               </div>
           </div>
         </div>
     </div>
 </div>
+<script>
+    get(`/replies/<%=article.getId()%>`)
+        .then(replies => {
+            replies.forEach(reply=>appendReplyDocument(reply));
+        })
+        .catch(error=>{
+            console.error("error : ",error);
+        });
 
-<script type="text/template" id="answerTemplate">
-	<article class="article">
-		<div class="article-header">
-			<div class="article-header-thumb">
-				<img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
-			</div>
-			<div class="article-header-text">
-				<a href="#" class="article-author-name">{0}</a>
-				<div class="article-header-time">{1}</div>
-			</div>
-		</div>
-		<div class="article-doc comment-doc">
-			{2}
-		</div>
-		<div class="article-util">
-		<ul class="article-util-list">
-			<li>
-				<a class="link-modify-article" href="/api/qna/updateAnswer/{3}">수정</a>
-			</li>
-			<li>
-				<form class="delete-answer-form" action="/api/questions/{3}/answers/{4}" method="POST">
-					<input type="hidden" name="_method" value="DELETE">
-                     <button type="submit" class="delete-answer-button">삭제</button>
-				</form>
-			</li>
-		</ul>
-		</div>
-	</article>
+    document.querySelector("#replyPostBtn").addEventListener("click",(e)=>{
+        const value = document.querySelector("#replyContents").value;
+        post("/replies",{"contents":value,"articleId":<%=article.getId()%>})
+            .then(reply =>{
+                document.querySelector('#replyContents').value = "";
+                appendReplyDocument(reply);
+            })
+            .catch(exception =>{
+                console.error(exception);
+                alert(exception);
+            })
+    })
+
+    function appendReplyDocument(reply) {
+
+        const element = createArticle(reply);
+        const delBtn = element.querySelector('#delBtn');
+        delBtn.addEventListener("click",(e)=>{
+           del(`/replies/\${reply.replyId}`)
+               .then(response => {
+                   document.querySelector('#comment-box').removeChild(element);
+               })
+               .catch(exception=>{
+                   console.log(exception);
+                   alert("자신의 댓글이 아닙니다.");
+               })
+
+        });
+        document.querySelector('#comment-box').appendChild(element);
+    }
+    function createArticle(reply) {
+        // article 요소 생성 및 클래스, ID 설정
+        const article = document.createElement('article');
+        article.className = 'article';
+        article.id = `answer-\${reply.id}`; // reply 객체에 id가 있다고 가정
+
+        // article-header 생성
+        const articleHeader = document.createElement('div');
+        articleHeader.className = 'article-header';
+
+        // article-header-thumb 생성 및 img 추가
+        const articleHeaderThumb = document.createElement('div');
+        articleHeaderThumb.className = 'article-header-thumb';
+        const authorThumb = document.createElement('img');
+        authorThumb.className = 'article-author-thumb';
+        authorThumb.src = 'https://graph.facebook.com/v2.3/1324855987/picture'; // 여기에 실제 URL 사용
+        authorThumb.alt = '';
+        articleHeaderThumb.appendChild(authorThumb);
+
+        // article-header-text 생성 및 내용 추가
+        const articleHeaderText = document.createElement('div');
+        articleHeaderText.className = 'article-header-text';
+        const authorLink = document.createElement('a');
+        authorLink.href = `/members/\${reply.memberId}`;
+        authorLink.className = 'article-author-name';
+        authorLink.textContent = reply.memberNickname;
+        const timeLink = document.createElement('a');
+        timeLink.href = `#answer-\${reply.id}`;
+        timeLink.className = 'article-header-time';
+        timeLink.title = '퍼머링크';
+        timeLink.textContent = '2016-01-12 14:06'; // 여기서도 실제 시간을 사용
+        articleHeaderText.appendChild(authorLink);
+        articleHeaderText.appendChild(timeLink);
+
+        // article-header에 요소 추가
+        articleHeader.appendChild(articleHeaderThumb);
+        articleHeader.appendChild(articleHeaderText);
+
+        // article-doc 생성 및 내용 추가
+        const articleDoc = document.createElement('div');
+        articleDoc.className = 'article-doc comment-doc';
+        const p = document.createElement('p');
+        p.textContent = reply.contents;
+        articleDoc.appendChild(p);
+
+        // article-util 생성
+        const articleUtil = document.createElement('div');
+        articleUtil.className = 'article-util';
+        const utilList = document.createElement('ul');
+        utilList.className = 'article-util-list';
+
+        // 수정 링크
+        const modifyItem = document.createElement('li');
+        const modifyLink = document.createElement('a');
+        modifyLink.className = 'link-modify-article';
+        modifyLink.href = `/questions/413/answers/\${reply.id}/form`;
+        modifyLink.textContent = '수정';
+        modifyItem.appendChild(modifyLink);
+
+        // 삭제 버튼
+        const deleteItem = document.createElement('li');
+        const deleteButton = document.createElement('input');
+        deleteButton.type = 'button';
+        deleteButton.id = 'delBtn';
+        deleteButton.className = 'delete-answer-button';
+        deleteButton.value = '삭제';
+        deleteItem.appendChild(deleteButton);
+
+        // utilList에 수정 및 삭제 추가
+        utilList.appendChild(modifyItem);
+        utilList.appendChild(deleteItem);
+
+        // articleUtil에 utilList 추가
+        articleUtil.appendChild(utilList);
+
+        // article에 모든 요소 추가
+        article.appendChild(articleHeader);
+        article.appendChild(articleDoc);
+        article.appendChild(articleUtil);
+
+        return article;
+    }
 </script>
-	</body>
+<script type="text/template" id="answerTemplate">
+    <article class="article">
+        <div class="article-header">
+            <div class="article-header-thumb">
+                <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
+            </div>
+            <div class="article-header-text">
+                <a href="#" class="article-author-name">{0}</a>
+                <div class="article-header-time">{1}</div>
+            </div>
+        </div>
+        <div class="article-doc comment-doc">
+            {2}
+        </div>
+        <div class="article-util">
+            <ul class="article-util-list">
+                <li>
+                    <a class="link-modify-article" href="/api/qna/updateAnswer/{3}">수정</a>
+                </li>
+                <li>
+                    <form class="delete-answer-form" action="/api/questions/{3}/answers/{4}" method="POST">
+                        <input type="hidden" name="_method" value="DELETE">
+                        <button type="submit" class="delete-answer-button">삭제</button>
+                    </form>
+                </li>
+            </ul>
+        </div>
+    </article>
+</script>
+</body>
 </html>

--- a/src/main/webapp/templates/qna/show.jsp
+++ b/src/main/webapp/templates/qna/show.jsp
@@ -21,7 +21,7 @@
                           <img src="https://graph.facebook.com/v2.3/100000059371774/picture" class="article-author-thumb" alt="">
                       </div>
                       <div class="article-header-text">
-                          <a href="${pageContext.request.contextPath}/members/<%=article.getWriter()%>" class="article-author-name"><%=article.getWriter()%></a>
+                          <a href="${pageContext.request.contextPath}/members/<%=article.getWriter().getMemberId()%>" class="article-author-name"><%=article.getWriter().getNickname()%></a>
                           <a href="/questions/413" class="article-header-time" title="퍼머링크">
                               2015-12-30 01:47
                               <i class="icon-link"></i>
@@ -34,7 +34,7 @@
                   <div class="article-util">
                       <ul class="article-util-list">
                           <%
-                              if(article.getWriter().equals(member.getMemberId())){
+                              if(article.getWriter().getId().equals(member.getId())){
                           %>
                           <li>
                               <a class="link-modify-article" href="/questions/<%=article.getId()%>/form">수정</a>

--- a/src/test/java/com/hyeonuk/jspcafe/article/dao/InMemoryArticleDaoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/dao/InMemoryArticleDaoTest.java
@@ -2,6 +2,7 @@ package com.hyeonuk.jspcafe.article.dao;
 
 import com.hyeonuk.jspcafe.article.domain.Article;
 import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
+import com.hyeonuk.jspcafe.member.domain.Member;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,7 +30,7 @@ class InMemoryArticleDaoTest {
         @Test
         @DisplayName("유효한 게시글을 저장하고 반환한다")
         void saveValidArticle() {
-            Article article = new Article("writer", "title", "contents");
+            Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title", "contents");
             Article savedArticle = articleDao.save(article);
 
             assertNotNull(savedArticle.getId());
@@ -41,7 +42,7 @@ class InMemoryArticleDaoTest {
         @Test
         @DisplayName("이미 존재하는 게시글을 저장하면 업데이트된다.")
         void updateArticle(){
-            Article article = new Article("writer", "title", "contents");
+            Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title", "contents");
             articleDao.save(article);
 
             article.setContents("updatedContent");
@@ -66,35 +67,42 @@ class InMemoryArticleDaoTest {
             @Test
             @DisplayName("title이 null이면 예외를 던진다")
             void saveWithNullTitle() {
-                Article article = new Article("writer", null, "contents");
+                Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), null, "contents");
                 assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
             }
 
             @Test
             @DisplayName("contents가 null이면 예외를 던진다")
             void saveWithNullContents() {
-                Article article = new Article("writer", "title", null);
+                Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title", null);
                 assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
             }
 
             @Test
-            @DisplayName("writer가 빈 문자열이면 예외를 던진다")
-            void saveWithEmptyWriter() {
-                Article article = new Article("", "title", "contents");
+            @DisplayName("writer가 null이면 예외를 던진다.")
+            void saveWithNullWriterId() {
+                Article article = new Article(null, "title", "contents");
+                assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
+            }
+
+            @Test
+            @DisplayName("writer의 id가 Null 이면 예외를 던진다.")
+            void saveWithEmptyWriterId() {
+                Article article = new Article(new Member(null,"id1","pw1","nickname1","email1"), "title", "contents");
                 assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
             }
 
             @Test
             @DisplayName("title이 빈 문자열이면 예외를 던진다")
             void saveWithEmptyTitle() {
-                Article article = new Article("writer", "", "contents");
+                Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "", "contents");
                 assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
             }
 
             @Test
             @DisplayName("contents가 빈 문자열이면 예외를 던진다")
             void saveWithEmptyContents() {
-                Article article = new Article("writer", "title", "");
+                Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title", "");
                 assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
             }
         }
@@ -107,8 +115,8 @@ class InMemoryArticleDaoTest {
         @Test
         @DisplayName("모든 게시글을 반환한다")
         void findAllArticles() {
-            Article article1 = new Article("writer1", "title1", "contents1");
-            Article article2 = new Article("writer2", "title2", "contents2");
+            Article article1 = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title1", "contents1");
+            Article article2 = new Article(new Member(2l,"id2","pw2","nick2","email2"), "title2", "contents2");
             articleDao.save(article1);
             articleDao.save(article2);
 
@@ -124,7 +132,7 @@ class InMemoryArticleDaoTest {
         @Test
         @DisplayName("ID로 게시글을 찾고 반환한다")
         void findArticleById() {
-            Article article = new Article("writer", "title", "contents");
+            Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title", "contents");
             Article savedArticle = articleDao.save(article);
 
             Optional<Article> foundArticle = articleDao.findById(savedArticle.getId());
@@ -147,7 +155,7 @@ class InMemoryArticleDaoTest {
         @DisplayName("존재하는 article id면 삭제한다.")
         void deleteArticleByIdSuccess() throws Exception{
             //given
-            Article article = new Article(1l,"writer","title","contents");
+            Article article = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title","contents");
             articleDao.save(article);
 
             //when

--- a/src/test/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDaoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/dao/MysqlArticleDaoTest.java
@@ -4,6 +4,7 @@ import com.hyeonuk.jspcafe.article.domain.Article;
 import com.hyeonuk.jspcafe.global.db.DBConnectionInfo;
 import com.hyeonuk.jspcafe.global.db.DBManagerIml;
 import com.hyeonuk.jspcafe.global.exception.DataIntegrityViolationException;
+import com.hyeonuk.jspcafe.member.domain.Member;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,7 +33,7 @@ class MysqlArticleDaoTest {
         @Test
         @DisplayName("유효한 게시글을 저장하고 반환한다")
         void saveValidArticle() {
-            Article article = new Article("writer", "title", "contents");
+            Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title", "contents");
             Article savedArticle = articleDao.save(article);
 
             assertNotNull(savedArticle.getId());
@@ -45,7 +46,7 @@ class MysqlArticleDaoTest {
         @Test
         @DisplayName("이미 존재하는 게시글을 저장하면 업데이트된다.")
         void updateArticle(){
-            Article article = new Article("writer", "title", "contents");
+            Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title", "contents");
             articleDao.save(article);
 
             article.setContents("updatedContent");
@@ -70,35 +71,42 @@ class MysqlArticleDaoTest {
             @Test
             @DisplayName("title이 null이면 예외를 던진다")
             void saveWithNullTitle() {
-                Article article = new Article("writer", null, "contents");
+                Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), null, "contents");
                 assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
             }
 
             @Test
             @DisplayName("contents가 null이면 예외를 던진다")
             void saveWithNullContents() {
-                Article article = new Article("writer", "title", null);
+                Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title", null);
                 assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
             }
 
             @Test
-            @DisplayName("writer가 빈 문자열이면 예외를 던진다")
+            @DisplayName("writer가 null이면 예외를 던진다")
             void saveWithEmptyWriter() {
-                Article article = new Article("", "title", "contents");
+                Article article = new Article(null, "title", "contents");
+                assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
+            }
+
+            @Test
+            @DisplayName("writer의 id가 null이면 예외를 던진다")
+            void saveWithEmptyWriterId() {
+                Article article = new Article(new Member(null,"id1","pw1","nick1","email1"), "title", "contents");
                 assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
             }
 
             @Test
             @DisplayName("title이 빈 문자열이면 예외를 던진다")
             void saveWithEmptyTitle() {
-                Article article = new Article("writer", "", "contents");
+                Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "", "contents");
                 assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
             }
 
             @Test
             @DisplayName("contents가 빈 문자열이면 예외를 던진다")
             void saveWithEmptyContents() {
-                Article article = new Article("writer", "title", "");
+                Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title", "");
                 assertThrows(DataIntegrityViolationException.class, () -> articleDao.save(article));
             }
         }
@@ -111,8 +119,8 @@ class MysqlArticleDaoTest {
         @Test
         @DisplayName("모든 게시글을 반환한다")
         void findAllArticles() {
-            Article article1 = new Article("writer1", "title1", "contents1");
-            Article article2 = new Article("writer2", "title2", "contents2");
+            Article article1 = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title1", "contents1");
+            Article article2 = new Article(new Member(2l,"id2","pw2","nick2","email2"), "title2", "contents2");
             articleDao.save(article1);
             articleDao.save(article2);
 
@@ -128,7 +136,7 @@ class MysqlArticleDaoTest {
         @Test
         @DisplayName("ID로 게시글을 찾고 반환한다")
         void findArticleById() {
-            Article article = new Article("writer", "title", "contents");
+            Article article = new Article(new Member(1l,"id1","pw1","nick1","email1"), "title", "contents");
             Article savedArticle = articleDao.save(article);
 
             Optional<Article> foundArticle = articleDao.findById(savedArticle.getId());
@@ -151,7 +159,7 @@ class MysqlArticleDaoTest {
         @DisplayName("존재하는 article id면 삭제한다.")
         void deleteArticleByIdSuccess() throws Exception{
             //given
-            Article article = new Article(1l,"writer","title","contents");
+            Article article = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title","contents");
             articleDao.save(article);
 
             //when

--- a/src/test/java/com/hyeonuk/jspcafe/article/domain/ArticleTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/domain/ArticleTest.java
@@ -1,5 +1,6 @@
 package com.hyeonuk.jspcafe.article.domain;
 
+import com.hyeonuk.jspcafe.member.domain.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,10 +17,11 @@ class ArticleTest {
         @Test
         @DisplayName("모든 필드를 포함한 생성자는 필드가 올바르게 설정된다.")
         void allFieldsConstructor() {
-            Article article = new Article(1L, "writer", "title", "contents");
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(1L, member, "title", "contents");
 
             assertEquals(1L, article.getId());
-            assertEquals("writer", article.getWriter());
+            assertEquals(member, article.getWriter());
             assertEquals("title", article.getTitle());
             assertEquals("contents", article.getContents());
         }
@@ -27,10 +29,11 @@ class ArticleTest {
         @Test
         @DisplayName("ID 없이 생성자는 필드가 올바르게 설정된다.")
         void noIdConstructor() {
-            Article article = new Article("writer", "title", "contents");
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(member, "title", "contents");
 
             assertNull(article.getId());
-            assertEquals("writer", article.getWriter());
+            assertEquals(member, article.getWriter());
             assertEquals("title", article.getTitle());
             assertEquals("contents", article.getContents());
         }
@@ -43,7 +46,8 @@ class ArticleTest {
         @Test
         @DisplayName("ID getter/setter는 값을 올바르게 설정하고 반환한다.")
         void idGetterSetter() {
-            Article article = new Article("writer", "title", "contents");
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(member, "title", "contents");
             article.setId(1L);
 
             assertEquals(1L, article.getId());
@@ -52,16 +56,19 @@ class ArticleTest {
         @Test
         @DisplayName("writer getter/setter는 값을 올바르게 설정하고 반환한다.")
         void writerGetterSetter() {
-            Article article = new Article("writer", "title", "contents");
-            article.setWriter("newWriter");
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Member newMember = new Member(2l,"id2","pw2","nick2","email2");
+            Article article = new Article(member, "title", "contents");
+            article.setWriter(newMember);
 
-            assertEquals("newWriter", article.getWriter());
+            assertEquals(newMember, article.getWriter());
         }
 
         @Test
         @DisplayName("title getter/setter는 값을 올바르게 설정하고 반환한다.")
         void titleGetterSetter() {
-            Article article = new Article("writer", "title", "contents");
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(member, "title", "contents");
             article.setTitle("newTitle");
 
             assertEquals("newTitle", article.getTitle());
@@ -70,7 +77,8 @@ class ArticleTest {
         @Test
         @DisplayName("contents getter/setter는 값을 올바르게 설정하고 반환한다.")
         void contentsGetterSetter() {
-            Article article = new Article("writer", "title", "contents");
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(member, "title", "contents");
             article.setContents("newContents");
 
             assertEquals("newContents", article.getContents());
@@ -84,7 +92,8 @@ class ArticleTest {
         @Test
         @DisplayName("유효한 Article 객체는 true를 반환한다.")
         void validArticle() {
-            Article article = new Article("writer", "title", "contents");
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(member, "title", "contents");
 
             assertTrue(article.validation());
         }
@@ -98,9 +107,10 @@ class ArticleTest {
         }
 
         @Test
-        @DisplayName("writer가 blank이면 false를 반환한다.")
+        @DisplayName("writer의 id가 null이면 false를 반환한다.")
         void writerIsBlank() {
-            Article article = new Article("   ", "title", "contents");
+            Member member = new Member(null,"id1","pw1","nick1","email1");
+            Article article = new Article(member, "title", "contents");
 
             assertFalse(article.validation());
         }
@@ -108,7 +118,8 @@ class ArticleTest {
         @Test
         @DisplayName("title이 null이면 false를 반환한다.")
         void titleIsNull() {
-            Article article = new Article("writer", null, "contents");
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(member, null, "contents");
 
             assertFalse(article.validation());
         }
@@ -116,7 +127,8 @@ class ArticleTest {
         @Test
         @DisplayName("title이 blank이면 false를 반환한다.")
         void titleIsBlank() {
-            Article article = new Article("writer", "   ", "contents");
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(member, "   ", "contents");
 
             assertFalse(article.validation());
         }
@@ -124,7 +136,8 @@ class ArticleTest {
         @Test
         @DisplayName("contents가 null이면 false를 반환한다.")
         void contentsIsNull() {
-            Article article = new Article("writer", "title", null);
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(member, "title", null);
 
             assertFalse(article.validation());
         }
@@ -132,7 +145,8 @@ class ArticleTest {
         @Test
         @DisplayName("contents가 blank이면 false를 반환한다.")
         void contentsIsBlank() {
-            Article article = new Article("writer", "title", "   ");
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(member, "title", "   ");
 
             assertFalse(article.validation());
         }

--- a/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServletTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServletTest.java
@@ -48,11 +48,11 @@ class ArticleControlServletTest {
         @DisplayName("제대로 된 요청이 들어온 경우, 해당하는 article을 반환한다.")
         void success() throws Exception {
             //given
-            Article article1 = new Article(1l, "writer1", "title1", "content1");
-            Article article2 = new Article(2l, "writer2", "title2", "content2");
-            Article article3 = new Article(3l, "writer3", "title3", "content3");
-            Article article4 = new Article(4l, "writer4", "title4", "content4");
-            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo("/" + article1.getId());
@@ -74,11 +74,11 @@ class ArticleControlServletTest {
         @DisplayName("작성자가 자신의 게시글의 /{id}/form 으로 들어온 경우")
         void formPath() throws Exception {
             //given
-            Article article1 = new Article(1l, "writer1", "title1", "content1");
-            Article article2 = new Article(2l, "writer2", "title2", "content2");
-            Article article3 = new Article(3l, "writer3", "title3", "content3");
-            Article article4 = new Article(4l, "writer4", "title4", "content4");
-            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo("/1/form");
@@ -103,11 +103,11 @@ class ArticleControlServletTest {
         @DisplayName("작성자가 자신이 아닌 게시글의 /{id}/form 으로 들어온 경우")
         void formPathWithOtherArticle() throws Exception {
             //given
-            Article article1 = new Article(1l, "writer1", "title1", "content1");
-            Article article2 = new Article(2l, "writer2", "title2", "content2");
-            Article article3 = new Article(3l, "writer3", "title3", "content3");
-            Article article4 = new Article(4l, "writer4", "title4", "content4");
-            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo("/1/form");
@@ -125,11 +125,11 @@ class ArticleControlServletTest {
         @DisplayName("pathInfo가 null인 경우")
         void nullPathInfo() throws Exception {
             //given
-            Article article1 = new Article(1l, "writer1", "title1", "content1");
-            Article article2 = new Article(2l, "writer2", "title2", "content2");
-            Article article3 = new Article(3l, "writer3", "title3", "content3");
-            Article article4 = new Article(4l, "writer4", "title4", "content4");
-            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo(null);
@@ -144,11 +144,11 @@ class ArticleControlServletTest {
         @DisplayName("pathInfo가 empty인 경우")
         void emptyPathInfo() throws Exception {
             //given
-            Article article1 = new Article(1l, "writer1", "title1", "content1");
-            Article article2 = new Article(2l, "writer2", "title2", "content2");
-            Article article3 = new Article(3l, "writer3", "title3", "content3");
-            Article article4 = new Article(4l, "writer4", "title4", "content4");
-            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo("");
@@ -163,11 +163,11 @@ class ArticleControlServletTest {
         @DisplayName("pathInfo가 /인  경우")
         void slashPathInfo() throws Exception {
             //given
-            Article article1 = new Article(1l, "writer1", "title1", "content1");
-            Article article2 = new Article(2l, "writer2", "title2", "content2");
-            Article article3 = new Article(3l, "writer3", "title3", "content3");
-            Article article4 = new Article(4l, "writer4", "title4", "content4");
-            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo("/");
@@ -184,11 +184,11 @@ class ArticleControlServletTest {
         @DisplayName("pathInfo가 /{id}/{anyNumber}으로 들어온 경우")
         void manyPathVariables() throws Exception {
             //given
-            Article article1 = new Article(1l, "writer1", "title1", "content1");
-            Article article2 = new Article(2l, "writer2", "title2", "content2");
-            Article article3 = new Article(3l, "writer3", "title3", "content3");
-            Article article4 = new Article(4l, "writer4", "title4", "content4");
-            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo("/1/2");
@@ -203,11 +203,11 @@ class ArticleControlServletTest {
         @DisplayName("pathInfo가 /{id}/{form 이외의 string}으로 들어온 경우")
         void manyPathVariablesWithString() throws Exception {
             //given
-            Article article1 = new Article(1l, "writer1", "title1", "content1");
-            Article article2 = new Article(2l, "writer2", "title2", "content2");
-            Article article3 = new Article(3l, "writer3", "title3", "content3");
-            Article article4 = new Article(4l, "writer4", "title4", "content4");
-            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo("/1/anyString");
@@ -222,11 +222,11 @@ class ArticleControlServletTest {
         @DisplayName("pathInfo가 /{id}/{anyString}/{anyString}으로 들어온 경우")
         void manyPathVariablesWithStringDouble() throws Exception {
             //given
-            Article article1 = new Article(1l, "writer1", "title1", "content1");
-            Article article2 = new Article(2l, "writer2", "title2", "content2");
-            Article article3 = new Article(3l, "writer3", "title3", "content3");
-            Article article4 = new Article(4l, "writer4", "title4", "content4");
-            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo("/1/anyString/otherString");
@@ -241,11 +241,11 @@ class ArticleControlServletTest {
         @DisplayName("pathInfo가 숫자가 아닌 string으로 들어온 경우")
         void pathInfoWithStringId() throws Exception {
             //given
-            Article article1 = new Article(1l, "writer1", "title1", "content1");
-            Article article2 = new Article(2l, "writer2", "title2", "content2");
-            Article article3 = new Article(3l, "writer3", "title3", "content3");
-            Article article4 = new Article(4l, "writer4", "title4", "content4");
-            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo("/helloworld");
@@ -260,11 +260,11 @@ class ArticleControlServletTest {
         @DisplayName("article이 존재하지 않는 경우")
         void notExistsArticle() throws Exception {
             //given
-            Article article1 = new Article(1l, "writer1", "title1", "content1");
-            Article article2 = new Article(2l, "writer2", "title2", "content2");
-            Article article3 = new Article(3l, "writer3", "title3", "content3");
-            Article article4 = new Article(4l, "writer4", "title4", "content4");
-            Article article5 = new Article(5l, "writer5", "title5", "content5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
             req.setPathInfo("/6");
@@ -323,7 +323,7 @@ class ArticleControlServletTest {
             void badRequestMethodValue() throws Exception {
                 //given
                 Member member = new Member(1l, "id1", "pw1", "nick1", "email1");
-                Article article1 = new Article(1l, member.getMemberId(), "title1", "content1");
+                Article article1 = new Article(1l, member, "title1", "content1");
                 articleDao.save(article1);
                 req.setPathInfo("/"+ article1.getId());
                 req.setParameter("_method","otherMethod");
@@ -353,11 +353,11 @@ class ArticleControlServletTest {
             @DisplayName("pathInfo가 /{id}/{anyString}으로 들어온 경우")
             void manyPathVariablesWithString() throws Exception {
                 //given
-                Article article1 = new Article(1l, "writer1", "title1", "content1");
-                Article article2 = new Article(2l, "writer2", "title2", "content2");
-                Article article3 = new Article(3l, "writer3", "title3", "content3");
-                Article article4 = new Article(4l, "writer4", "title4", "content4");
-                Article article5 = new Article(5l, "writer5", "title5", "content5");
+                Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+                Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+                Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+                Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+                Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
                 List<Article> articles = List.of(article1, article2, article3, article4, article5);
                 articles.forEach(articleDao::save);
                 req.setPathInfo("/1/anyString");
@@ -389,7 +389,7 @@ class ArticleControlServletTest {
             void methodPut() throws Exception {
                 //given
                 Member member = new Member(1l,"id1","pw1","nick1","email1");
-                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                Article article = new Article(1l,member,"beforeUpdateTitle","beforeUpdateContents");
                 String updateTitle = "updatedTitle";
                 String updateContents = "updatedContents";
                 articleDao.save(article);
@@ -424,7 +424,7 @@ class ArticleControlServletTest {
                 //given
                 Member member = new Member(1l,"id1","pw1","nick1","email1");
                 Member member2 = new Member(2l,"id2","pw2","nick2","email2");
-                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                Article article = new Article(1l,member,"beforeUpdateTitle","beforeUpdateContents");
                 String updateTitle = "updatedTitle";
                 String updateContents = "updatedContents";
                 articleDao.save(article);
@@ -459,7 +459,7 @@ class ArticleControlServletTest {
             void methodPutWithNullTitle() throws Exception {
                 //given
                 Member member = new Member(1l,"id1","pw1","nick1","email1");
-                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                Article article = new Article(1l,member,"beforeUpdateTitle","beforeUpdateContents");
                 String updateTitle = null;
                 String updateContents = "updatedContents";
                 articleDao.save(article);
@@ -494,7 +494,7 @@ class ArticleControlServletTest {
             void methodPutWithBlankTitle() throws Exception {
                 //given
                 Member member = new Member(1l,"id1","pw1","nick1","email1");
-                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                Article article = new Article(1l,member,"beforeUpdateTitle","beforeUpdateContents");
                 String updateTitle = "    ";
                 String updateContents = "updatedContents";
                 articleDao.save(article);
@@ -529,7 +529,7 @@ class ArticleControlServletTest {
             void methodPutWithNullContents() throws Exception {
                 //given
                 Member member = new Member(1l,"id1","pw1","nick1","email1");
-                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                Article article = new Article(1l,member,"beforeUpdateTitle","beforeUpdateContents");
                 String updateTitle = "updatedTitle";
                 String updateContents = null;
                 articleDao.save(article);
@@ -564,7 +564,7 @@ class ArticleControlServletTest {
             void methodPutWithBlankContents() throws Exception {
                 //given
                 Member member = new Member(1l,"id1","pw1","nick1","email1");
-                Article article = new Article(1l,member.getMemberId(),"beforeUpdateTitle","beforeUpdateContents");
+                Article article = new Article(1l,member,"beforeUpdateTitle","beforeUpdateContents");
                 String updateTitle = "updatedTitle";
                 String updateContents = "    ";
                 articleDao.save(article);
@@ -603,7 +603,7 @@ class ArticleControlServletTest {
             void deleteSuccessTest() throws Exception{
                 //given
                 Member member = new Member(1l,"id1","pw1","nick1","email1");
-                Article article = new Article(1l,member.getMemberId(),"title","contents");
+                Article article = new Article(1l,member,"title","contents");
                 articleDao.save(article);
                 MockSession session = new MockSession();
                 session.setAttribute("member",member);
@@ -628,7 +628,7 @@ class ArticleControlServletTest {
                 //given
                 Member member = new Member(1l,"id1","pw1","nick1","email1");
                 Member member2 = new Member(2l,"id2","pw2","nick2","email2");
-                Article article = new Article(1l,member.getMemberId(),"title","contents");
+                Article article = new Article(1l,member,"title","contents");
                 articleDao.save(article);
                 MockSession session = new MockSession();
                 session.setAttribute("member",member2);

--- a/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServletTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServletTest.java
@@ -7,6 +7,7 @@ import com.hyeonuk.jspcafe.global.exception.HttpBadRequestException;
 import com.hyeonuk.jspcafe.global.exception.HttpNotFoundException;
 import com.hyeonuk.jspcafe.member.domain.Member;
 import com.hyeonuk.jspcafe.member.servlets.mock.*;
+import com.hyeonuk.jspcafe.reply.dao.ReplyDao;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpSession;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +29,7 @@ class ArticleControlServletTest {
     private MockResponse res;
     private ArticleDao articleDao;
     private ArticleControlServlet servlet;
+    private ReplyDao replyDao;
 
     @BeforeEach
     void setUp() throws ServletException {

--- a/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServletTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleControlServletTest.java
@@ -7,6 +7,7 @@ import com.hyeonuk.jspcafe.global.exception.HttpBadRequestException;
 import com.hyeonuk.jspcafe.global.exception.HttpNotFoundException;
 import com.hyeonuk.jspcafe.member.domain.Member;
 import com.hyeonuk.jspcafe.member.servlets.mock.*;
+import com.hyeonuk.jspcafe.reply.dao.InMemoryReplyDao;
 import com.hyeonuk.jspcafe.reply.dao.ReplyDao;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpSession;
@@ -36,9 +37,11 @@ class ArticleControlServletTest {
         req = new MockRequest();
         res = new MockResponse();
         articleDao = new InMemoryArticleDao();
+        replyDao = new InMemoryReplyDao();
         servlet = new ArticleControlServlet();
         ServletContext servletContext = new MockServletContext();
         servletContext.setAttribute("articleDao", articleDao);
+        servletContext.setAttribute("replyDao",replyDao);
         ServletConfig servletConfig = new BaseServletConfig(servletContext);
         servlet.init(servletConfig);
     }

--- a/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleListServletTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleListServletTest.java
@@ -3,6 +3,7 @@ package com.hyeonuk.jspcafe.article.servlet;
 import com.hyeonuk.jspcafe.article.dao.ArticleDao;
 import com.hyeonuk.jspcafe.article.dao.InMemoryArticleDao;
 import com.hyeonuk.jspcafe.article.domain.Article;
+import com.hyeonuk.jspcafe.member.domain.Member;
 import com.hyeonuk.jspcafe.member.servlets.mock.*;
 import jakarta.servlet.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,11 +43,11 @@ class ArticleListServletTest {
         @Test
         void forwardWithAllArticles() throws ServletException, IOException {
             //given
-            Article article1 = new Article(1l,"writer1","title1","contents1");
-            Article article2 = new Article(2l,"writer2","title2","contents2");
-            Article article3 = new Article(3l,"writer3","title3","contents3");
-            Article article4 = new Article(4l,"writer4","title4","contents4");
-            Article article5 = new Article(5l,"writer5","title5","contents5");
+            Article article1 = new Article(1l,new Member(1l,"id1","pw1","nick1","email1"),"title1","contents1");
+            Article article2 = new Article(2l,new Member(2l,"id2","pw2","nick2","email2"),"title2","contents2");
+            Article article3 = new Article(3l,new Member(3l,"id3","pw3","nick3","email3"),"title3","contents3");
+            Article article4 = new Article(4l,new Member(4l,"id4","pw4","nick4","email4"),"title4","contents4");
+            Article article5 = new Article(5l,new Member(5l,"id5","pw5","nick5","email5"),"title5","contents5");
             List<Article> articles = List.of(article1, article2, article3, article4, article5);
             articles.forEach(articleDao::save);
 

--- a/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleRegistServletTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/article/servlet/ArticleRegistServletTest.java
@@ -76,7 +76,7 @@ class ArticleRegistServletTest {
             //then
             assertEquals(1,articleDao.findAll().size());
             Article saved = articleDao.findAll().get(0);
-            assertEquals(saved.getWriter(),member.getMemberId());
+            assertEquals(saved.getWriter().getId(),member.getId());
             assertEquals(saved.getTitle(),title);
             assertEquals(saved.getContents(),contents);
             assertEquals("/",res.getRedirection());

--- a/src/test/java/com/hyeonuk/jspcafe/member/servlets/MemberControlServletTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/member/servlets/MemberControlServletTest.java
@@ -183,6 +183,12 @@ public class MemberControlServletTest {
             assertEquals("newemail1@gmail.com", updatedMember.getEmail());
             assertEquals("newnick1", updatedMember.getNickname());
             assertEquals("/members/id1", resp.getRedirection());
+
+            Member updatedSession = (Member)req.getSession().getAttribute("member");
+
+            assertTrue(passwordEncoder.match("newpw1", updatedSession.getPassword()));
+            assertEquals("newemail1@gmail.com", updatedSession.getEmail());
+            assertEquals("newnick1", updatedSession.getNickname());
         }
 
         @DisplayName("path가 유효하지 않을때, 즉 pathInfo가 null로 들어올 경우 400오류를 던짐")

--- a/src/test/java/com/hyeonuk/jspcafe/reply/dao/InMemoryReplyDaoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/reply/dao/InMemoryReplyDaoTest.java
@@ -1,0 +1,246 @@
+package com.hyeonuk.jspcafe.reply.dao;
+
+import com.hyeonuk.jspcafe.article.dao.ArticleDao;
+import com.hyeonuk.jspcafe.article.dao.InMemoryArticleDao;
+import com.hyeonuk.jspcafe.article.domain.Article;
+import com.hyeonuk.jspcafe.member.dao.InMemoryMemberDao;
+import com.hyeonuk.jspcafe.member.dao.MemberDao;
+import com.hyeonuk.jspcafe.member.domain.Member;
+import com.hyeonuk.jspcafe.reply.domain.Reply;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("InMemoryReplyDao 클래스")
+class InMemoryReplyDaoTest {
+    private MemberDao memberDao = new InMemoryMemberDao();
+    private ArticleDao articleDao = new InMemoryArticleDao();
+    private ReplyDao replyDao = new InMemoryReplyDao();
+
+    private Member member = new Member(1l,"memberId1","password1","nickname1","email1");
+    private Member member2 = new Member(2l,"memberId2","password2","nickname2","email2");
+    private Article article = new Article(1l,member,"title1","contents1");
+
+    @BeforeEach
+    void setUp(){
+        memberDao.save(member);
+        memberDao.save(member2);
+        articleDao.save(article);
+    }
+
+    @Nested
+    @DisplayName("save 메서드는")
+    class SaveMethod{
+        @Test
+        @DisplayName("댓글의 ID값이 없으면 저장된다.")
+        void saveWithoutId(){
+            //given
+            Reply reply = new Reply(article,member2,"reply1");
+
+            //when
+            replyDao.save(reply);
+
+            //then
+            Optional<Reply> byId = replyDao.findById(reply.getId());
+            assertTrue(byId.isPresent());
+            Reply saved = byId.get();
+            assertEquals(reply.getId(),saved.getId());
+            assertEquals(reply.getArticle().getId(),saved.getArticle().getId());
+            assertEquals(reply.getMember().getId(),saved.getMember().getId());
+        }
+
+        @Test
+        @DisplayName("댓글의 ID값이 있으나, db에 정보가 없으면 저장된다..")
+        void saveWithId(){
+            //given
+            Reply reply = new Reply(1l,article,member2,"reply1");
+
+            //when
+            replyDao.save(reply);
+
+            //then
+            Optional<Reply> byId = replyDao.findById(reply.getId());
+            assertTrue(byId.isPresent());
+            Reply saved = byId.get();
+            assertEquals(reply.getId(),saved.getId());
+            assertEquals(reply.getArticle().getId(),saved.getArticle().getId());
+            assertEquals(reply.getMember().getId(),saved.getMember().getId());
+        }
+
+        @Test
+        @DisplayName("댓글의 ID값이 있으나, db에 정보가 있으면 업데이트 된다..")
+        void saveWithIdUpdate(){
+            //given
+            Reply reply = new Reply(1l,article,member2,"reply1");
+            replyDao.save(reply);
+            Reply update = new Reply(1l,article,member2,"reply2");
+
+            //when
+            replyDao.save(update);
+
+            //then
+            Optional<Reply> byId = replyDao.findById(update.getId());
+            assertTrue(byId.isPresent());
+            Reply saved = byId.get();
+            assertEquals(update.getId(),saved.getId());
+            assertEquals(update.getArticle().getId(),saved.getArticle().getId());
+            assertEquals(update.getMember().getId(),saved.getMember().getId());
+            assertEquals(1,replyDao.findAllByArticleId(article.getId()).size());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteById 메서드는")
+    class DeleteByIdMethod{
+        @Test
+        @DisplayName("저장된 id를 입력받으면 잘 삭제된다.")
+        void deleteById(){
+            //given
+            Reply reply = new Reply(1l,article,member2,"reply1");
+            replyDao.save(reply);
+
+            //when
+            replyDao.deleteById(reply.getId());
+
+            //then
+            assertTrue(replyDao.findById(reply.getId()).isEmpty());
+        }
+        @Test
+        @DisplayName("저장된 id가 없으면 아무일도 안생긴다.")
+        void deleteByIdWithoutData(){
+            //given
+            Long replyId = Long.MAX_VALUE;
+            boolean isEmpty = replyDao.findById(replyId).isEmpty();
+
+            //when
+            replyDao.deleteById(replyId);
+
+            //then
+            assertTrue(isEmpty);
+            assertTrue(replyDao.findById(replyId).isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteAllByArticleId 메서드는")
+    class DeleteAllByArticleIdMethod{
+        @Test
+        @DisplayName("articleId에 해당하는 reply를 모두 삭제한다. 다른 게시글의 댓글은 삭제되지 않는다.")
+        void deleteAllByArticleId(){
+            //given
+            Article otherArticle = new Article(member,"other title","other contents");
+            articleDao.save(otherArticle);
+            Reply otherReply = new Reply(10l,otherArticle,member,"contents");
+            replyDao.save(otherReply);
+
+            Reply reply1 = new Reply(1l,article,member2,"reply1");
+            Reply reply2 = new Reply(2l,article,member2,"reply2");
+            Reply reply3 = new Reply(3l,article,member,"reply3");
+            replyDao.save(reply1);
+            replyDao.save(reply2);
+            replyDao.save(reply3);
+
+            //when
+            replyDao.deleteAllByArticleId(article.getId());
+
+            //then
+            assertTrue(replyDao.findById(reply1.getId()).isEmpty());
+            assertTrue(replyDao.findById(reply2.getId()).isEmpty());
+            assertTrue(replyDao.findById(reply3.getId()).isEmpty());
+            assertTrue(replyDao.findAllByArticleId(article.getId()).isEmpty());
+
+            assertTrue(replyDao.findById(otherReply.getId()).isPresent());
+        }
+    }
+
+    @Nested
+    @DisplayName("findById 메서드는")
+    class FindByIdMethod{
+        @Test
+        @DisplayName("id값이 존재하면 해당 reply를 반환한다.")
+        void findById(){
+            //given
+            Reply reply = new Reply(1l,article,member,"reply");
+            replyDao.save(reply);
+
+            //when
+            Optional<Reply> byId = replyDao.findById(reply.getId());
+
+            //then
+            assertTrue(byId.isPresent());
+            Reply find = byId.get();
+            assertEquals(reply.getId(),find.getId());
+            assertEquals(reply.getContents(),find.getContents());
+            assertEquals(reply.getMember().getId(),find.getMember().getId());
+            assertEquals(reply.getArticle().getId(),find.getArticle().getId());
+        }
+
+        @Test
+        @DisplayName("삭제된 id값은 null을 반환한다.")
+        void findByWithDeletedId(){
+            //given
+            Reply reply = new Reply(1l,article,member,"reply");
+            replyDao.save(reply);
+            replyDao.deleteById(reply.getId());
+
+            //when
+            Optional<Reply> byId = replyDao.findById(reply.getId());
+
+            //then
+            assertTrue(byId.isEmpty());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 값은 null을 반환한다.")
+        void findByNoneId(){
+            //given
+
+            //when
+            Optional<Reply> byId = replyDao.findById(Long.MAX_VALUE);
+
+            //then
+            assertTrue(byId.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByArticleId 메서드는")
+    class FindAllByArticleIdMethod{
+        @Test
+        @DisplayName("articleId에 해당하는 댓글을 모두 가져온다.")
+        void findAllByArticleId(){
+            //given
+            Reply reply1 = new Reply(1l,article,member,"reply1");
+            Reply reply2 = new Reply(2l,article,member,"reply2");
+            Reply reply3 = new Reply(3l,article,member,"reply3");
+            List<Reply> replies = List.of(reply1,reply2,reply3);
+            replyDao.save(reply1);
+            replyDao.save(reply2);
+            replyDao.save(reply3);
+
+            //when
+            List<Reply> findAll = replyDao.findAllByArticleId(article.getId());
+
+            //then
+            assertEquals(replies.size(),findAll.size());
+        }
+
+        @Test
+        @DisplayName("articleId에 해당하는 댓글이 존재하지 않는다면 빈 리스트를 반환한다..")
+        void findAllByArticleIdWithEmptyList(){
+            //given
+
+            //when
+            List<Reply> findAll = replyDao.findAllByArticleId(article.getId());
+
+            //then
+            assertTrue(findAll.isEmpty());
+        }
+    }
+}

--- a/src/test/java/com/hyeonuk/jspcafe/reply/dao/MysqlReplyDaoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/reply/dao/MysqlReplyDaoTest.java
@@ -1,0 +1,261 @@
+package com.hyeonuk.jspcafe.reply.dao;
+
+import com.hyeonuk.jspcafe.article.dao.ArticleDao;
+import com.hyeonuk.jspcafe.article.dao.InMemoryArticleDao;
+import com.hyeonuk.jspcafe.article.dao.MysqlArticleDao;
+import com.hyeonuk.jspcafe.article.domain.Article;
+import com.hyeonuk.jspcafe.global.db.DBConnectionInfo;
+import com.hyeonuk.jspcafe.global.db.DBManager;
+import com.hyeonuk.jspcafe.global.db.DBManagerIml;
+import com.hyeonuk.jspcafe.member.dao.InMemoryMemberDao;
+import com.hyeonuk.jspcafe.member.dao.MemberDao;
+import com.hyeonuk.jspcafe.member.dao.MysqlMemberDao;
+import com.hyeonuk.jspcafe.member.domain.Member;
+import com.hyeonuk.jspcafe.reply.domain.Reply;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("MysqlReplyDao 클래스")
+class MysqlReplyDaoTest {
+    private MemberDao memberDao;
+    private ArticleDao articleDao;
+    private ReplyDao replyDao;
+
+    private Member member = new Member(1l,"memberId1","password1","nickname1","email1");
+    private Member member2 = new Member(2l,"memberId2","password2","nickname2","email2");
+    private Article article = new Article(1l,member,"title1","contents1");
+
+    @BeforeEach
+    void setUp() throws SQLException, ClassNotFoundException {
+        DBConnectionInfo con = new DBConnectionInfo("application-testdb.yml");
+        DBManager manager = new DBManagerIml(con);
+
+        memberDao = new MysqlMemberDao(manager);
+        articleDao = new MysqlArticleDao(manager);
+        replyDao = new MysqlReplyDao(manager);
+
+
+        memberDao.save(member);
+        memberDao.save(member2);
+        articleDao.save(article);
+    }
+
+    @Nested
+    @DisplayName("save 메서드는")
+    class SaveMethod{
+        @Test
+        @DisplayName("댓글의 ID값이 없으면 저장된다.")
+        void saveWithoutId(){
+            //given
+            Reply reply = new Reply(article,member2,"reply1");
+
+            //when
+            replyDao.save(reply);
+
+            //then
+            Optional<Reply> byId = replyDao.findById(reply.getId());
+            assertTrue(byId.isPresent());
+            Reply saved = byId.get();
+            assertEquals(reply.getId(),saved.getId());
+            assertEquals(reply.getArticle().getId(),saved.getArticle().getId());
+            assertEquals(reply.getMember().getId(),saved.getMember().getId());
+        }
+
+        @Test
+        @DisplayName("댓글의 ID값이 있으나, db에 정보가 없으면 저장된다..")
+        void saveWithId(){
+            //given
+            Reply reply = new Reply(1l,article,member2,"reply1");
+
+            //when
+            replyDao.save(reply);
+
+            //then
+            Optional<Reply> byId = replyDao.findById(reply.getId());
+            assertTrue(byId.isPresent());
+            Reply saved = byId.get();
+            assertEquals(reply.getId(),saved.getId());
+            assertEquals(reply.getArticle().getId(),saved.getArticle().getId());
+            assertEquals(reply.getMember().getId(),saved.getMember().getId());
+        }
+
+        @Test
+        @DisplayName("댓글의 ID값이 있으나, db에 정보가 있으면 업데이트 된다..")
+        void saveWithIdUpdate(){
+            //given
+            Reply reply = new Reply(1l,article,member2,"reply1");
+            replyDao.save(reply);
+            Reply update = new Reply(1l,article,member2,"reply2");
+
+            //when
+            replyDao.save(update);
+
+            //then
+            Optional<Reply> byId = replyDao.findById(update.getId());
+            assertTrue(byId.isPresent());
+            Reply saved = byId.get();
+            assertEquals(update.getId(),saved.getId());
+            assertEquals(update.getArticle().getId(),saved.getArticle().getId());
+            assertEquals(update.getMember().getId(),saved.getMember().getId());
+            assertEquals(1,replyDao.findAllByArticleId(article.getId()).size());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteById 메서드는")
+    class DeleteByIdMethod{
+        @Test
+        @DisplayName("저장된 id를 입력받으면 잘 삭제된다.")
+        void deleteById(){
+            //given
+            Reply reply = new Reply(1l,article,member2,"reply1");
+            replyDao.save(reply);
+
+            //when
+            replyDao.deleteById(reply.getId());
+
+            //then
+            assertTrue(replyDao.findById(reply.getId()).isEmpty());
+        }
+        @Test
+        @DisplayName("저장된 id가 없으면 아무일도 안생긴다.")
+        void deleteByIdWithoutData(){
+            //given
+            Long replyId = Long.MAX_VALUE;
+            boolean isEmpty = replyDao.findById(replyId).isEmpty();
+
+            //when
+            replyDao.deleteById(replyId);
+
+            //then
+            assertTrue(isEmpty);
+            assertTrue(replyDao.findById(replyId).isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteAllByArticleId 메서드는")
+    class DeleteAllByArticleIdMethod{
+        @Test
+        @DisplayName("articleId에 해당하는 reply를 모두 삭제한다. 다른 게시글의 댓글은 삭제되지 않는다.")
+        void deleteAllByArticleId(){
+            //given
+            Article otherArticle = new Article(member,"other title","other contents");
+            articleDao.save(otherArticle);
+            Reply otherReply = new Reply(10l,otherArticle,member,"contents");
+            replyDao.save(otherReply);
+
+            Reply reply1 = new Reply(1l,article,member2,"reply1");
+            Reply reply2 = new Reply(2l,article,member2,"reply2");
+            Reply reply3 = new Reply(3l,article,member,"reply3");
+            replyDao.save(reply1);
+            replyDao.save(reply2);
+            replyDao.save(reply3);
+
+            //when
+            replyDao.deleteAllByArticleId(article.getId());
+
+            //then
+            assertTrue(replyDao.findById(reply1.getId()).isEmpty());
+            assertTrue(replyDao.findById(reply2.getId()).isEmpty());
+            assertTrue(replyDao.findById(reply3.getId()).isEmpty());
+            assertTrue(replyDao.findAllByArticleId(article.getId()).isEmpty());
+
+            assertTrue(replyDao.findById(otherReply.getId()).isPresent());
+        }
+    }
+
+    @Nested
+    @DisplayName("findById 메서드는")
+    class FindByIdMethod{
+        @Test
+        @DisplayName("id값이 존재하면 해당 reply를 반환한다.")
+        void findById(){
+            //given
+            Reply reply = new Reply(1l,article,member,"reply");
+            replyDao.save(reply);
+
+            //when
+            Optional<Reply> byId = replyDao.findById(reply.getId());
+
+            //then
+            assertTrue(byId.isPresent());
+            Reply find = byId.get();
+            assertEquals(reply.getId(),find.getId());
+            assertEquals(reply.getContents(),find.getContents());
+            assertEquals(reply.getMember().getId(),find.getMember().getId());
+            assertEquals(reply.getArticle().getId(),find.getArticle().getId());
+        }
+
+        @Test
+        @DisplayName("삭제된 id값은 null을 반환한다.")
+        void findByWithDeletedId(){
+            //given
+            Reply reply = new Reply(1l,article,member,"reply");
+            replyDao.save(reply);
+            replyDao.deleteById(reply.getId());
+
+            //when
+            Optional<Reply> byId = replyDao.findById(reply.getId());
+
+            //then
+            assertTrue(byId.isEmpty());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 값은 null을 반환한다.")
+        void findByNoneId(){
+            //given
+
+            //when
+            Optional<Reply> byId = replyDao.findById(Long.MAX_VALUE);
+
+            //then
+            assertTrue(byId.isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByArticleId 메서드는")
+    class FindAllByArticleIdMethod{
+        @Test
+        @DisplayName("articleId에 해당하는 댓글을 모두 가져온다.")
+        void findAllByArticleId(){
+            //given
+            Reply reply1 = new Reply(1l,article,member,"reply1");
+            Reply reply2 = new Reply(2l,article,member,"reply2");
+            Reply reply3 = new Reply(3l,article,member,"reply3");
+            List<Reply> replies = List.of(reply1,reply2,reply3);
+            replyDao.save(reply1);
+            replyDao.save(reply2);
+            replyDao.save(reply3);
+
+            //when
+            List<Reply> findAll = replyDao.findAllByArticleId(article.getId());
+
+            //then
+            assertEquals(replies.size(),findAll.size());
+        }
+
+        @Test
+        @DisplayName("articleId에 해당하는 댓글이 존재하지 않는다면 빈 리스트를 반환한다..")
+        void findAllByArticleIdWithEmptyList(){
+            //given
+
+            //when
+            List<Reply> findAll = replyDao.findAllByArticleId(article.getId());
+
+            //then
+            assertTrue(findAll.isEmpty());
+        }
+    }
+}

--- a/src/test/java/com/hyeonuk/jspcafe/reply/domain/ReplyTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/reply/domain/ReplyTest.java
@@ -1,0 +1,208 @@
+package com.hyeonuk.jspcafe.reply.domain;
+
+import com.hyeonuk.jspcafe.article.domain.Article;
+import com.hyeonuk.jspcafe.member.domain.Member;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Reply 도메인 객체 테스트")
+public class ReplyTest {
+
+    @Nested
+    @DisplayName("생성자 및 Getter/Setter")
+    class ConstructorAndAccessors {
+
+        @Test
+        @DisplayName("Reply 객체 생성 및 필드 접근")
+        void createAndAccessFields() {
+            // Given
+            Long id = 1L;
+            Member member = new Member(3L, "username", "password", "nickname", "email@example.com");
+            Article article = new Article(2L, member, "Content", "Author");
+            String contents = "This is a reply.";
+            Date deletedAt = new Date();
+
+            // When
+            Reply reply = new Reply(id, article, member, contents, deletedAt);
+
+            // Then
+            assertEquals(id, reply.getId());
+            assertEquals(article, reply.getArticle());
+            assertEquals(member, reply.getMember());
+            assertEquals(contents, reply.getContents());
+            assertEquals(deletedAt, reply.getDeletedAt());
+        }
+
+        @Test
+        @DisplayName("Reply 객체 Setter 테스트")
+        void setFields() {
+            // Given
+            Reply reply = new Reply(null, null, null, null, null);
+
+            // When
+            Long id = 1L;
+            Member member = new Member(3L, "username", "password", "nickname", "email@example.com");
+            Article article = new Article(2L, member, "Content", "Author");
+            String contents = "This is a reply.";
+            Date deletedAt = new Date();
+
+            reply.setId(id);
+            reply.setArticle(article);
+            reply.setMember(member);
+            reply.setContents(contents);
+            reply.setDeletedAt(deletedAt);
+
+            // Then
+            assertEquals(id, reply.getId());
+            assertEquals(article, reply.getArticle());
+            assertEquals(member, reply.getMember());
+            assertEquals(contents, reply.getContents());
+            assertEquals(deletedAt, reply.getDeletedAt());
+        }
+
+        @Test
+        @DisplayName("Reply 객체 생성자 오버로딩 테스트")
+        void constructorOverloading() {
+            // Given
+            Member member = new Member(3L, "username", "password", "nickname", "email@example.com");
+            Article article = new Article(2L, member,"Title", "Content" );
+            String contents = "This is a reply.";
+
+            // When
+            Reply reply1 = new Reply(1L, article, member, contents);
+            Reply reply2 = new Reply(article, member, contents);
+
+            // Then
+            assertNotNull(reply1);
+            assertNotNull(reply2);
+            assertNull(reply2.getId());
+            assertEquals(article, reply2.getArticle());
+            assertEquals(member, reply2.getMember());
+            assertEquals(contents, reply2.getContents());
+        }
+    }
+
+    @Nested
+    @DisplayName("Interaction: 유효성 검사")
+    class Validation {
+
+        @Test
+        @DisplayName("유효한 Reply 객체")
+        void validReply() {
+            // Given
+            Member member = new Member(3L, "username", "password", "nickname", "email@example.com");
+            Article article = new Article(2L, member,"Title", "Content");
+            String contents = "This is a valid reply.";
+            Reply reply = new Reply(1L, article, member, contents);
+
+            // When
+            boolean isValid = reply.validation();
+
+            // Then
+            assertTrue(isValid, "Reply 객체가 유효해야 함");
+        }
+
+        @Test
+        @DisplayName("ID가 null일 경우 유효성 검사 실패")
+        void invalidReplyWithoutId() {
+            // Given
+            Member member = new Member(3L, "username", "password", "nickname", "email@example.com");
+            Article article = new Article(2L, member,"Title", "Content");
+            String contents = "This is a valid reply.";
+            Reply reply = new Reply(null, article, member, contents);
+
+            // When
+            boolean isValid = reply.validation();
+
+            // Then
+            assertFalse(isValid, "ID가 없으면 Reply 객체가 유효하지 않음");
+        }
+
+        @Test
+        @DisplayName("Article이 null일 경우 유효성 검사 실패")
+        void invalidReplyWithoutArticle() {
+            // Given
+            Member member = new Member(3L, "username", "password", "nickname", "email@example.com");
+            String contents = "This is a valid reply.";
+            Reply reply = new Reply(1L, null, member, contents);
+
+            // When
+            boolean isValid = reply.validation();
+
+            // Then
+            assertFalse(isValid, "Article이 없으면 Reply 객체가 유효하지 않음");
+        }
+
+        @Test
+        @DisplayName("Article의 id가 null일 경우 유효성 검사 실패")
+        void invalidReplyWithoutArticleId() {
+            // Given
+            Member member = new Member(3L, "username", "password", "nickname", "email@example.com");
+            String contents = "This is a valid reply.";
+            Reply reply = new Reply(1L, new Article(member,"title","contents"), member, contents);
+
+            // When
+            boolean isValid = reply.validation();
+
+            // Then
+            assertFalse(isValid, "Article이 없으면 Reply 객체가 유효하지 않음");
+        }
+
+        @Test
+        @DisplayName("Member가 null일 경우 유효성 검사 실패")
+        void invalidReplyWithoutMember() {
+            // Given
+            Member member = new Member(3L, "username", "password", "nickname", "email@example.com");
+            Article article = new Article(2L,member,"Title", "Content");
+            String contents = "This is a valid reply.";
+            Reply reply = new Reply(1L, article, null, contents);
+
+            // When
+            boolean isValid = reply.validation();
+
+            // Then
+            assertFalse(isValid, "Member가 없으면 Reply 객체가 유효하지 않음");
+        }
+
+        @Test
+        @DisplayName("Member의 id가 null인 경우 유효성 검사 실패")
+        void invalidReplyWithoutMemberId() {
+            // Given
+            Member member = new Member(3L, "username", "password", "nickname", "email@example.com");
+            Article article = new Article(2L,member,"Title", "Content");
+            String contents = "This is a valid reply.";
+            Member idNullMember = new Member("username","password","nickname2","email");
+            Reply reply = new Reply(1L, article, idNullMember, contents);
+
+            // When
+            boolean isValid = reply.validation();
+
+            // Then
+            assertFalse(isValid, "Member가 없으면 Reply 객체가 유효하지 않음");
+        }
+
+        @Test
+        @DisplayName("Contents가 null이거나 비어 있을 경우 유효성 검사 실패")
+        void invalidReplyWithoutContents() {
+            // Given
+            Member member = new Member(3L, "username", "password", "nickname", "email@example.com");
+            Article article = new Article(2L, member,"Title", "Content");
+
+            // When
+            Reply reply1 = new Reply(1L, article, member, null);
+            Reply reply2 = new Reply(1L, article, member, "   ");
+
+            boolean isValid1 = reply1.validation();
+            boolean isValid2 = reply2.validation();
+
+            // Then
+            assertFalse(isValid1, "Contents가 null이면 Reply 객체가 유효하지 않음");
+            assertFalse(isValid2, "Contents가 빈 문자열이면 Reply 객체가 유효하지 않음");
+        }
+    }
+}

--- a/src/test/java/com/hyeonuk/jspcafe/reply/dto/ReplyDtoTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/reply/dto/ReplyDtoTest.java
@@ -1,0 +1,73 @@
+package com.hyeonuk.jspcafe.reply.dto;
+
+import com.hyeonuk.jspcafe.article.domain.Article;
+import com.hyeonuk.jspcafe.member.domain.Member;
+import com.hyeonuk.jspcafe.reply.domain.Reply;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ReplyDto 테스트")
+public class ReplyDtoTest {
+
+    @Nested
+    @DisplayName("from 메서드")
+    class FromMethod {
+        @Test
+        @DisplayName("Reply를 ReplyDto로 변환")
+        void fromReplyToReplyDto() {
+            // Given
+            Long replyId = 1L;
+            Long memberId = 2L;
+            Long articleId = 3L;
+            String contents = "This is a reply.";
+            String nickname = "JohnDoe";
+
+            Member member = new Member(memberId, "john", "password", nickname, "john@example.com");
+            Article article = new Article(articleId, member, "Article Content", "Author");
+            Reply reply = new Reply(replyId, article, member, contents);
+
+            // When
+            ReplyDto replyDto = ReplyDto.from(reply);
+
+            // Then
+            assertEquals(replyId, replyDto.getReplyId());
+            assertEquals(memberId, replyDto.getMemberId());
+            assertEquals(nickname, replyDto.getMemberNickname());
+            assertEquals(articleId, replyDto.getArticleId());
+            assertEquals(contents, replyDto.getContents());
+        }
+    }
+
+    @Nested
+    @DisplayName("Getter 및 Setter")
+    class GettersAndSetters {
+        @Test
+        @DisplayName("필드 값 설정 및 가져오기")
+        void testGettersAndSetters() {
+            // Given
+            Long replyId = 1L;
+            Long memberId = 2L;
+            Long articleId = 3L;
+            String contents = "This is a reply.";
+            String nickname = "JohnDoe";
+
+            // When
+            ReplyDto replyDto = new ReplyDto();
+            replyDto.setReplyId(replyId);
+            replyDto.setMemberId(memberId);
+            replyDto.setArticleId(articleId);
+            replyDto.setContents(contents);
+            replyDto.setMemberNickname(nickname);
+
+            // Then
+            assertEquals(replyId, replyDto.getReplyId());
+            assertEquals(memberId, replyDto.getMemberId());
+            assertEquals(nickname, replyDto.getMemberNickname());
+            assertEquals(articleId, replyDto.getArticleId());
+            assertEquals(contents, replyDto.getContents());
+        }
+    }
+}

--- a/src/test/java/com/hyeonuk/jspcafe/reply/servlet/ReplyControlServletTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/reply/servlet/ReplyControlServletTest.java
@@ -1,0 +1,351 @@
+package com.hyeonuk.jspcafe.reply.servlet;
+
+import com.hyeonuk.jspcafe.article.dao.ArticleDao;
+import com.hyeonuk.jspcafe.article.dao.MysqlArticleDao;
+import com.hyeonuk.jspcafe.article.domain.Article;
+import com.hyeonuk.jspcafe.global.db.DBConnectionInfo;
+import com.hyeonuk.jspcafe.global.db.DBManagerIml;
+import com.hyeonuk.jspcafe.member.dao.MemberDao;
+import com.hyeonuk.jspcafe.member.dao.MysqlMemberDao;
+import com.hyeonuk.jspcafe.member.domain.Member;
+import com.hyeonuk.jspcafe.member.servlets.mock.*;
+import com.hyeonuk.jspcafe.reply.dao.MysqlReplyDao;
+import com.hyeonuk.jspcafe.reply.dao.ReplyDao;
+import com.hyeonuk.jspcafe.reply.domain.Reply;
+import com.hyeonuk.jspcafe.reply.dto.ReplyDto;
+import com.hyeonuk.jspcafe.utils.ObjectMapper;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("ReplyControlServlet 클래스")
+class ReplyControlServletTest {
+    private ReplyControlServlet replyControlServlet;
+    private ReplyDao replyDao;
+    private ArticleDao articleDao;
+    private MemberDao memberDao;
+    private ObjectMapper objectMapper;
+    private MockRequest req;
+    private MockResponse res;
+
+    @BeforeEach
+    void setUp() throws SQLException, ClassNotFoundException, ServletException {
+        DBConnectionInfo connectionInfo = new DBConnectionInfo("application-testdb.yml");
+        DBManagerIml manager = new DBManagerIml(connectionInfo);
+        articleDao = new MysqlArticleDao(manager);
+        replyDao = new MysqlReplyDao(manager);
+        memberDao = new MysqlMemberDao(manager);
+        objectMapper = new ObjectMapper();
+        MockServletContext servletContext = new MockServletContext();
+        BaseServletConfig servletConfig = new BaseServletConfig(servletContext);
+        servletContext.setAttribute("articleDao",articleDao);
+        servletContext.setAttribute("replyDao",replyDao);
+        servletContext.setAttribute("objectMapper",objectMapper);
+
+        replyControlServlet = new ReplyControlServlet();
+        replyControlServlet.init(servletConfig);
+
+        req = new MockRequest();
+        res = new MockResponse();
+    }
+
+    @DisplayName("doGet 메서드는")
+    @Nested
+    class DoGet {
+        @Test
+        @DisplayName("articleId의 댓글들을 모두 불러올 수 있다.")
+        public void canLoadAllReplies() throws Exception {
+            //given
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Member replier1 = new Member(2l,"id2","pw2","nick2","email2");
+            Member replier2 = new Member(3l,"id3","pw3","nick3","email3");
+            Member replier3 = new Member(4l,"id4","pw4","nick4","email4");
+            Article article = new Article(1l,member,"title!","contents!");
+            memberDao.save(member);
+            memberDao.save(replier1);
+            memberDao.save(replier2);
+            memberDao.save(replier3);
+            articleDao.save(article);
+            Reply reply1 = new Reply(1l,article,replier1,"reply1");
+            Reply reply2 = new Reply(2l,article,replier2,"reply2");
+            Reply reply3 = new Reply(3l,article,replier3,"reply3");
+            List<Reply> replies = List.of(reply1,reply2,reply3);
+            List<ReplyDto> expected = replies.stream()
+                    .map(ReplyDto::from)
+                    .collect(Collectors.toList());
+            replyDao.save(reply1);
+            replyDao.save(reply2);
+            replyDao.save(reply3);
+
+            req.setPathInfo("/"+article.getId());
+
+            //when
+            replyControlServlet.doGet(req,res);
+
+            //then
+            String body = res.getBody();
+            assertEquals(objectMapper.toJson(expected),body);
+        }
+    }
+
+    @DisplayName("doPost 메서드는")
+    @Nested
+    class DoPost{
+        @DisplayName("댓글을 저장할 수 있다.")
+        @Test
+        void replySaveTest() throws Exception {
+            //given
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(1l,member,"title","contents");
+            memberDao.save(member);
+            articleDao.save(article);
+
+            MockSession session = new MockSession();
+            session.setAttribute("member",member);
+            req.setSession(session);
+
+            String contents = "contents";
+            String requestJson = "{\"contents\":\""+contents+"\",\"articleId\":"+article.getId()+"}";
+            req.setInputStream(new ByteArrayInputStream(requestJson.getBytes()));
+
+            //when
+            replyControlServlet.doPost(req,res);
+
+            //then
+            String response = res.getBody();
+            ReplyDto responseReply = objectMapper.fromJson(response, ReplyDto.class);
+            assertEquals(contents,responseReply.getContents());
+            assertEquals(article.getId(),responseReply.getArticleId());
+            assertTrue(replyDao.findById(responseReply.getReplyId()).isPresent());
+        }
+    }
+
+    @Nested
+    @DisplayName("doDelete메서드는")
+    class DoDelete{
+        @Test
+        @DisplayName("자신의 댓글을 삭제하면 삭제된다.")
+        void deleteMyReplyTest() throws Exception {
+            //given
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(1l,member,"title","contents");
+            Reply reply = new Reply(1l,article,member,"reply1");
+            memberDao.save(member);
+            articleDao.save(article);
+            replyDao.save(reply);
+
+            MockSession session = new MockSession();
+            session.setAttribute("member",member);
+            req.setSession(session);
+
+            req.setPathInfo("/"+reply.getId());
+
+            //when
+            replyControlServlet.doDelete(req,res);
+
+            //then
+            assertTrue(replyDao.findById(reply.getId()).isEmpty());
+        }
+
+        @Test
+        @DisplayName("자신의 댓글이 아닌 것은 삭제할 수 없다.")
+        void deleteOtherReplyTest() throws Exception{
+            //given
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(1l,member,"title","contents");
+            Reply reply = new Reply(1l,article,member,"reply1");
+            memberDao.save(member);
+            articleDao.save(article);
+            replyDao.save(reply);
+
+            MockSession session = new MockSession();
+            Member other = new Member(2l,"id2","pw2","nick2","email2");
+            session.setAttribute("member",other);
+            req.setSession(session);
+            req.setPathInfo("/"+reply.getId());
+
+
+            //when
+            replyControlServlet.doDelete(req,res);
+
+            //then
+            int status = res.getStatus();
+            assertEquals(SC_BAD_REQUEST,status);
+            assertTrue(replyDao.findById(reply.getId()).isPresent());
+        }
+
+        @Test
+        @DisplayName("없는 댓글을 삭제하면 exception을 던져 message를 전송한다.")
+        void deleteNoneExistsReplyTest() throws Exception{
+            //given
+            Member member = new Member(1l,"id1","pw1","nick1","email1");
+            Article article = new Article(1l,member,"title","contents");
+            memberDao.save(member);
+            articleDao.save(article);
+
+            MockSession session = new MockSession();
+            session.setAttribute("member",member);
+            req.setSession(session);
+            req.setPathInfo("/"+1);
+
+
+            //when
+            replyControlServlet.doDelete(req,res);
+
+            //then
+            int status = res.getStatus();
+            assertEquals(HttpServletResponse.SC_BAD_REQUEST,status);
+        }
+    }
+
+    private class MockRequest extends BaseHttpServletRequest {
+        private Map<String, Object> attributes = new HashMap<>();
+        private String forwardPath;
+        private String pathInfo;
+        private Map<String, String> parameters = new HashMap<>();
+        private MockSession session;
+        private InputStream is;
+        public void setInputStream(InputStream is) {
+            this.is = is;
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            return new ServletInputStream() {
+                @Override
+                public boolean isFinished() {
+                    return false;
+                }
+
+                @Override
+                public boolean isReady() {
+                    return false;
+                }
+
+                @Override
+                public void setReadListener(ReadListener readListener) {
+
+                }
+
+                @Override
+                public int read() throws IOException {
+                    return is.read();
+                }
+            };
+        }
+
+        public void setSession(MockSession session){
+            this.session = session;
+        }
+        @Override
+        public HttpSession getSession() {
+            return session;
+        }
+
+        @Override
+        public HttpSession getSession(boolean b) {
+            return session;
+        }
+
+        public void setPathInfo(String pathInfo) {
+            this.pathInfo = pathInfo;
+        }
+
+        @Override
+        public String getPathInfo() {
+            return this.pathInfo;
+        }
+
+        @Override
+        public Object getAttribute(String s) {
+            return attributes.get(s);
+        }
+
+        @Override
+        public String getParameter(String s) {
+            return parameters.get(s);
+        }
+
+        public void setParameter(String key, String value) {
+            parameters.put(key, value);
+        }
+
+        @Override
+        public void setAttribute(String s, Object o) {
+            attributes.put(s, o);
+        }
+
+        public String getForwardPath() {
+            return forwardPath;
+        }
+
+        @Override
+        public RequestDispatcher getRequestDispatcher(String s) {
+            return new RequestDispatcher() {
+                @Override
+                public void forward(ServletRequest servletRequest, ServletResponse servletResponse) throws ServletException, IOException {
+                    forwardPath = s;
+                }
+
+                @Override
+                public void include(ServletRequest servletRequest, ServletResponse servletResponse) throws ServletException, IOException {
+
+                }
+            };
+        }
+    }
+
+    private class MockResponse extends BaseHttpServletResponse {
+        private String redirection;
+        private String body = null;
+        private ByteArrayOutputStream os = new ByteArrayOutputStream();
+        private PrintWriter writer = new PrintWriter(os);
+        private int status;
+
+        @Override
+        public void setStatus(int i) {
+            System.out.println("setCall = " + i);
+            this.status = i;
+        }
+
+
+        @Override
+        public int getStatus() {
+            return status;
+        }
+
+        @Override
+        public void sendRedirect(String redirection) {
+            this.redirection = redirection;
+        }
+
+        public String getRedirection() {
+            return this.redirection;
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return writer;
+        }
+
+        public String getBody(){
+            byte[] byteArray = os.toByteArray();
+            return new String(byteArray);
+        }
+    }
+}

--- a/src/test/java/com/hyeonuk/jspcafe/reply/servlet/ReplyControlServletTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/reply/servlet/ReplyControlServletTest.java
@@ -319,7 +319,6 @@ class ReplyControlServletTest {
 
         @Override
         public void setStatus(int i) {
-            System.out.println("setCall = " + i);
             this.status = i;
         }
 

--- a/src/test/java/com/hyeonuk/jspcafe/utils/ObjectMapperTest.java
+++ b/src/test/java/com/hyeonuk/jspcafe/utils/ObjectMapperTest.java
@@ -1,0 +1,146 @@
+package com.hyeonuk.jspcafe.utils;
+
+import com.hyeonuk.jspcafe.utils.obj.TestObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("ObjectMapper 클래스")
+class ObjectMapperTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Nested
+    @DisplayName("toJson 메서드는")
+    class Describe_toJson {
+
+        @Nested
+        @DisplayName("기본 타입이 주어졌을 때")
+        class Context_with_primitive_types {
+
+            @Test
+            @DisplayName("null을 변환한다")
+            void it_converts_null() {
+                assertEquals("null", objectMapper.toJson(null));
+            }
+
+            @Test
+            @DisplayName("숫자를 변환한다")
+            void it_converts_numbers() {
+                assertEquals("42", objectMapper.toJson(42));
+                assertEquals("3.14", objectMapper.toJson(3.14));
+            }
+
+            @Test
+            @DisplayName("불리언을 변환한다")
+            void it_converts_booleans() {
+                assertEquals("true", objectMapper.toJson(true));
+                assertEquals("false", objectMapper.toJson(false));
+            }
+
+            @Test
+            @DisplayName("문자열을 변환한다")
+            void it_converts_strings() {
+                assertEquals("\"Hello, World!\"", objectMapper.toJson("Hello, World!"));
+            }
+
+            @Test
+            @DisplayName("특수 문자가 포함된 문자열을 이스케이프 처리하여 변환한다")
+            void it_escapes_special_characters() {
+                assertEquals("\"\\\"\\\\\\b\\f\\n\\r\\t\"", objectMapper.toJson("\"\\\b\f\n\r\t"));
+            }
+        }
+
+        @Nested
+        @DisplayName("배열이 주어졌을 때")
+        class Context_with_arrays {
+
+            @Test
+            @DisplayName("Object 배열을 변환한다")
+            void it_converts_object_arrays() {
+                Object[] array = {1, "two", true};
+                assertEquals("[1,\"two\",true]", objectMapper.toJson(array));
+            }
+
+            @Test
+            @DisplayName("기본 타입 배열을 변환한다")
+            void it_converts_primitive_arrays() {
+                int[] intArray = {1, 2, 3};
+                assertEquals("[1,2,3]", objectMapper.toJson(intArray));
+            }
+        }
+
+        @Nested
+        @DisplayName("컬렉션이 주어졌을 때")
+        class Context_with_collections {
+
+            @Test
+            @DisplayName("List를 변환한다")
+            void it_converts_lists() {
+                List<Object> list = Arrays.asList(1, "two", true);
+                assertEquals("[1,\"two\",true]", objectMapper.toJson(list));
+            }
+
+            @Test
+            @DisplayName("Set을 변환한다")
+            void it_converts_sets() {
+                Set<String> set = new LinkedHashSet<>(Arrays.asList("a", "b", "c"));
+                assertEquals("[\"a\",\"b\",\"c\"]", objectMapper.toJson(set));
+            }
+        }
+
+        @Nested
+        @DisplayName("Map이 주어졌을 때")
+        class Context_with_maps {
+
+            @Test
+            @DisplayName("Map을 변환한다")
+            void it_converts_maps() {
+                Map<String, Object> map = new LinkedHashMap<>();
+                map.put("name", "John");
+                map.put("age", 30);
+                map.put("isStudent", false);
+                assertEquals("{\"name\":\"John\",\"age\":30,\"isStudent\":false}", objectMapper.toJson(map));
+            }
+        }
+
+        @Nested
+        @DisplayName("커스텀 객체가 주어졌을 때")
+        class Context_with_custom_objects {
+
+            @Test
+            @DisplayName("커스텀 객체를 변환한다")
+            void it_converts_custom_objects() {
+                TestObject obj = new TestObject("John", 30, true);
+                assertEquals("{\"name\":\"John\",\"age\":30,\"isStudent\":true}", objectMapper.toJson(obj));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("fromJson 메서드는")
+    class Describe_fromJson {
+        @Nested
+        @DisplayName("json 문자열이 들어왔을 때")
+        class Context_with_json {
+            @DisplayName("해당 객체로 파싱해준다.")
+            @Test
+            void it_converts_json() {
+                //given
+                String json = "{\"name\":\"John\",\"age\":30,\"isStudent\":true}";
+
+                //when
+                TestObject testObject = objectMapper.fromJson(json, TestObject.class);
+
+                //then
+                assertEquals("John",testObject.getName());
+                assertEquals(30,testObject.getAge());
+                assertEquals(true,testObject.isStudent());
+            }
+        }
+    }
+}

--- a/src/test/java/com/hyeonuk/jspcafe/utils/obj/TestObject.java
+++ b/src/test/java/com/hyeonuk/jspcafe/utils/obj/TestObject.java
@@ -1,0 +1,29 @@
+package com.hyeonuk.jspcafe.utils.obj;
+
+public class TestObject {
+    private String name;
+    private int age;
+    private boolean isStudent;
+
+    public TestObject(){
+
+    }
+
+    public TestObject(String name, int age, boolean isStudent) {
+        this.name = name;
+        this.age = age;
+        this.isStudent = isStudent;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public boolean isStudent() {
+        return isStudent;
+    }
+}

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -3,7 +3,7 @@ DROP TABLE IF EXISTS ARTICLE;
 DROP TABLE IF EXISTS MEMBER;
 
 -- member 테이블 생성
-CREATE TABLE MEMBER (
+CREATE TABLE member (
                         id BIGINT PRIMARY KEY AUTO_INCREMENT,
                         memberId VARCHAR(255) UNIQUE NOT NULL,
                         password VARCHAR(255) NOT NULL,
@@ -12,9 +12,9 @@ CREATE TABLE MEMBER (
 );
 
 -- article 테이블 생성
-CREATE TABLE ARTICLE (
+CREATE TABLE article (
                          id BIGINT PRIMARY KEY AUTO_INCREMENT,
                          title VARCHAR(255) NOT NULL,
-                         writer VARCHAR(255) NOT NULL,
+                         writer BIGINT NOT NULL,
                          contents TEXT NOT NULL
 );

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -1,6 +1,7 @@
 -- 기존 테이블이 존재한다면 삭제
 DROP TABLE IF EXISTS ARTICLE;
 DROP TABLE IF EXISTS MEMBER;
+DROP TABLE IF EXISTS REPLY;
 
 -- member 테이블 생성
 CREATE TABLE member (
@@ -16,12 +17,14 @@ CREATE TABLE article (
                          id BIGINT PRIMARY KEY AUTO_INCREMENT,
                          title VARCHAR(255) NOT NULL,
                          writer BIGINT NOT NULL,
-                         contents TEXT NOT NULL
+                         contents TEXT NOT NULL,
+                         deletedAt DATETIME DEFAULT NULL
 );
 
 CREATE TABLE reply (
                        id BIGINT PRIMARY KEY AUTO_INCREMENT,
                        articleId BIGINT NOT NULL,
                        memberId BIGINT NOT NULL,
-                       contents TEXT NOT NULL
+                       contents TEXT NOT NULL,
+                       deletedAt DATETIME DEFAULT NULL
 );

--- a/src/test/resources/init.sql
+++ b/src/test/resources/init.sql
@@ -18,3 +18,10 @@ CREATE TABLE article (
                          writer BIGINT NOT NULL,
                          contents TEXT NOT NULL
 );
+
+CREATE TABLE reply (
+                       id BIGINT PRIMARY KEY AUTO_INCREMENT,
+                       articleId BIGINT NOT NULL,
+                       memberId BIGINT NOT NULL,
+                       contents TEXT NOT NULL
+);


### PR DESCRIPTION
## 구현 내용
- 댓글 조회, 등록, 삭제 구현
- article을 삭제할 때 다른 사람의 댓글이 존재하는지 확인 후 존재하지 않으면 삭제, 존재하면 exception을 던지는 비즈니스 로직 추가

## 고민 사항
처음 실행할 때 모든 테이블을 drop 시킨 다음 다시 create하는데,  새로 만들지 아니면 기존에 있는 테이블을 사용할지에 대한 옵션값을 셋팅할 수 있는 기능에 대해 고민중 입니다.

또한, jdbc 코드의 공통 관심사를 분리하기 위해 jdbc template을 도입하고, 트랜잭션을 처리할 부분인 게시글 삭제 부분을 어떻게 처리할지에 대해 고민중입니다.

## 기타
커버리지는 아래와 같습니다.
<img width="729" alt="image" src="https://github.com/user-attachments/assets/b59c590d-b3da-42da-a530-3d1dedb66ad8">
