### PR TITLE
[강승훈] step-7  ajax 댓글 구현

### DIFF
--- a/src/main/java/codesquad/javacafe/AjaxController.java
+++ b/src/main/java/codesquad/javacafe/AjaxController.java
@@ -1,0 +1,47 @@
+package codesquad.javacafe;
+
+import codesquad.javacafe.comment.controller.CommentController;
+import codesquad.javacafe.common.SubController;
+import codesquad.javacafe.common.exception.ClientErrorCode;
+import codesquad.javacafe.common.exception.CustomException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@WebServlet("/ajax/*")
+public class AjaxController extends HttpServlet {
+    private static final Logger log = LoggerFactory.getLogger(AjaxController.class);
+    private static Map<String, SubController> ajaxController = new HashMap<>();
+    public void init() throws ServletException {
+        ajaxController.put("/comment", new CommentController());
+    }
+
+    @Override
+    protected void service(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        log.info("[FrontController] service, Request URI = {}, Http Method = {}", req.getRequestURI(), req.getMethod());
+        var uri = req.getRequestURI().replace("/ajax", "");
+        log.debug("[FrontController] uri = {}", uri);
+        var subController = ajaxController.get(uri);
+
+        try {
+            if (subController == null) {
+                log.error("Page Not Found");
+                throw ClientErrorCode.PAGE_NOT_FOUND.customException("요청 uri = " + uri);
+            }
+            subController.doProcess(req, res);
+        } catch (CustomException exception) {
+            // TODO error response
+            log.error("[Ajax Controller CustomException] message = {}" , exception.getMessage());
+        } catch (Exception exception) {
+            log.error("[AJAX CONTROLLER Exception] message = {}" , exception.getMessage());
+        }
+    }
+}

--- a/src/main/java/codesquad/javacafe/auth/controller/AuthController.java
+++ b/src/main/java/codesquad/javacafe/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import codesquad.javacafe.auth.service.AuthService;
 import codesquad.javacafe.common.SubController;
 import codesquad.javacafe.common.exception.ClientErrorCode;
 import codesquad.javacafe.member.service.MemberService;
+import codesquad.javacafe.post.service.PostService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -59,9 +60,9 @@ public class AuthController implements SubController {
 	}
 
 	public void redirectMainPage(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
-		var memberList = MemberService.getInstance().getMemberList();
-		req.setAttribute("memberList", memberList);
-		var dispatcher = req.getRequestDispatcher("/WEB-INF/user/list.jsp");
+		var postList = PostService.getInstance().getAllPosts();
+		req.setAttribute("postList", postList);
+		var dispatcher = req.getRequestDispatcher("/WEB-INF/index.jsp");
 		dispatcher.forward(req, res);
 	}
 }

--- a/src/main/java/codesquad/javacafe/comment/async/AsyncCommentDeleter.java
+++ b/src/main/java/codesquad/javacafe/comment/async/AsyncCommentDeleter.java
@@ -1,0 +1,44 @@
+package codesquad.javacafe.comment.async;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import codesquad.javacafe.comment.repository.CommentRepository;
+
+public class AsyncCommentDeleter {
+	private static final AsyncCommentDeleter instance = new AsyncCommentDeleter();
+	private static final Logger log = LoggerFactory.getLogger(AsyncCommentDeleter.class);
+	private final ExecutorService[] threadPoolExecutor;
+	private static final int MAX_QUEUE_ARRAY_SIZE = 10;
+
+	private AsyncCommentDeleter() {
+		threadPoolExecutor = new ExecutorService[MAX_QUEUE_ARRAY_SIZE];
+		for (int i = 0; i < MAX_QUEUE_ARRAY_SIZE; i++) {
+			threadPoolExecutor[i] = Executors.newSingleThreadExecutor();
+		}
+	}
+	public static AsyncCommentDeleter getInstance() {
+		return instance;
+	}
+
+	public void asyncDelete(long postId, AtomicInteger retryCount) {
+		var hashCode = (int)(postId % MAX_QUEUE_ARRAY_SIZE);
+
+		threadPoolExecutor[hashCode].execute(()->{
+			int result = CommentRepository.getInstance().deletePostComments(postId);
+			log.debug("[Post Comments All Deleted] delete count = "+result);
+			if (result == 0) {
+				var retry = retryCount.incrementAndGet();
+				if (retry == 5) {
+					log.error("[AsyncCommentDeleter] Failed to delete post comment with id {}", postId);
+				}else {
+					asyncDelete(postId,retryCount);
+				}
+			}
+		});
+	}
+}

--- a/src/main/java/codesquad/javacafe/comment/controller/CommentController.java
+++ b/src/main/java/codesquad/javacafe/comment/controller/CommentController.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Type;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public class CommentController implements SubController {
     private static final Logger log = LoggerFactory.getLogger(CommentController.class);
@@ -40,8 +41,12 @@ public class CommentController implements SubController {
                 var postId = Long.parseLong(req.getParameter("postId"));
                 var commentList = CommentService.getInstance().getCommentList(postId);
 
-                var jsonResponse = gson.toJson(commentList);
-                sendResponse(res, jsonResponse);
+                if (Objects.isNull(commentList)) {
+                    res.setStatus(HttpServletResponse.SC_NO_CONTENT);
+                } else {
+                    var jsonResponse = gson.toJson(commentList);
+                    sendResponse(res, jsonResponse);
+                }
 
                 break;
             }

--- a/src/main/java/codesquad/javacafe/comment/controller/CommentController.java
+++ b/src/main/java/codesquad/javacafe/comment/controller/CommentController.java
@@ -1,0 +1,111 @@
+package codesquad.javacafe.comment.controller;
+
+import codesquad.javacafe.comment.dto.request.CommentRequestDto;
+import codesquad.javacafe.comment.dto.response.CommentResponseDto;
+import codesquad.javacafe.comment.service.CommentService;
+import codesquad.javacafe.comment.util.LocalDateTimeSerializer;
+import codesquad.javacafe.common.SubController;
+import codesquad.javacafe.common.exception.ClientErrorCode;
+import codesquad.javacafe.common.exception.ServerErrorCode;
+import com.google.gson.*;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CommentController implements SubController {
+    private static final Logger log = LoggerFactory.getLogger(CommentController.class);
+
+    @Override
+    public void doProcess(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        log.info("[CommentController doProcess]");
+        var method = req.getMethod();
+        log.info("[CommentController doProcess] Method: {}", method);
+
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeSerializer())
+                .create();
+
+        switch (method){
+            case "GET":{
+                var postId = Long.parseLong(req.getParameter("postId"));
+                var commentList = CommentService.getInstance().getCommentList(postId);
+
+                var jsonResponse = gson.toJson(commentList);
+                sendResponse(res, jsonResponse);
+
+                break;
+            }
+            case "POST":{
+                Map<String, Object> body = getBody(req);
+                var commentRequestDto = new CommentRequestDto(body);
+                log.debug("[CommentController Save] commentRequestDto: {}", commentRequestDto);
+                var commentResponseDto = CommentService.getInstance().save(commentRequestDto);
+                log.debug("[CommentController Response DTO] commentResponseDto: {}", commentResponseDto);
+
+                var jsonResponse = gson.toJson(commentResponseDto);
+                log.debug("[CommentController Response JSON] jsonResponse: {}", jsonResponse);
+
+                sendResponse(res, jsonResponse);
+                break;
+            }
+            default: throw ClientErrorCode.METHOD_NOT_ALLOWED.customException("request uri = "+ req.getRequestURI() + ", request method = "+method);
+        }
+    }
+
+    private void sendResponse(HttpServletResponse res, String jsonResponse) {
+        res.setContentType("application/json");
+        res.setCharacterEncoding("UTF-8");
+        res.setStatus(HttpServletResponse.SC_CREATED);
+
+        try {
+            res.getWriter().write(jsonResponse);
+        } catch (IOException exception) {
+            throw ServerErrorCode.INTERNAL_SERVER_ERROR.customException(exception.getMessage());
+        }
+    }
+
+    private Map<String,Object> getBody(HttpServletRequest req) {
+        try {
+            Map<String, Object> data = new HashMap<>();
+
+            log.debug("input json");
+            StringBuilder jsonBuffer = new StringBuilder();
+            String line;
+            try (BufferedReader reader = new  BufferedReader(new InputStreamReader(req.getInputStream()))) {
+                while ((line = reader.readLine()) != null) {
+                    jsonBuffer.append(line);
+                }
+            }
+
+            Gson gson = new Gson();
+            JsonObject jsonObject = gson.fromJson(jsonBuffer.toString(), JsonObject.class);
+
+            log.debug("data get");
+            // Extract data from JSON object
+            long postId = jsonObject.get("postId").getAsLong();
+            long memberId = jsonObject.get("memberId").getAsLong();
+            String comment = jsonObject.get("comment").getAsString();
+            log.debug("data get success");
+            data.put("postId", postId);
+            data.put("memberId", memberId);
+            data.put("comment", comment);
+
+            log.debug("data = {}",data);
+
+
+            return data;
+        } catch (IOException exception) {
+            throw ServerErrorCode.INTERNAL_SERVER_ERROR.customException("exception occurred while reading request body, exception message = "+exception.getMessage());
+        }
+    }
+}

--- a/src/main/java/codesquad/javacafe/comment/dto/request/CommentRequestDto.java
+++ b/src/main/java/codesquad/javacafe/comment/dto/request/CommentRequestDto.java
@@ -1,0 +1,44 @@
+package codesquad.javacafe.comment.dto.request;
+
+import codesquad.javacafe.comment.entity.Comment;
+import codesquad.javacafe.common.exception.ClientErrorCode;
+import codesquad.javacafe.member.entity.Member;
+
+import java.util.Map;
+
+public class CommentRequestDto {
+    private long postId;
+    private long memberId;
+    private String comment;
+
+    public CommentRequestDto(long postId, long memberId, String comment) {
+        this.postId = postId;
+        this.memberId = memberId;
+        this.comment = comment;
+    }
+
+    public CommentRequestDto(Map<String,Object> body) {
+        try {
+            this.postId = (long) body.get("postId");
+            this.memberId = (long) body.get("memberId");
+            this.comment = (String) body.get("comment");
+        } catch (Exception exception) {
+            throw ClientErrorCode.PARAMETER_IS_NULL.customException("CommentRequestDto = " + body);
+        }
+    }
+
+    public Comment toEntity() {
+        var member = new Member();
+        member.setId(this.memberId);
+        return new Comment(this.postId, this.comment, member);
+    }
+
+    @Override
+    public String toString() {
+        return "CommentRequestDto{" +
+                "postId=" + postId +
+                ", memberId=" + memberId +
+                ", comment='" + comment + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/codesquad/javacafe/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/codesquad/javacafe/comment/dto/response/CommentResponseDto.java
@@ -1,0 +1,54 @@
+package codesquad.javacafe.comment.dto.response;
+
+import codesquad.javacafe.comment.entity.Comment;
+import codesquad.javacafe.member.entity.Member;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class CommentResponseDto {
+    private long id;
+    private long postId;
+    private String comment;
+    private LocalDateTime createdAt;
+    private Member member;
+
+    public CommentResponseDto(Comment comment) {
+        this.id = comment.getId();
+        this.postId = comment.getPostId();
+        this.member = comment.getMember();
+        this.comment = comment.getComment();
+        this.createdAt = comment.getCreatedAt();
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public long getPostId() {
+        return postId;
+    }
+
+    public long getMemberId() {
+        return member.getId();
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public String getCreatedAt() {
+        return createdAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+
+    @Override
+    public String toString() {
+        return "CommentResponseDto{" +
+                "id=" + id +
+                ", postId=" + postId +
+                ", comment='" + comment + '\'' +
+                ", createdAt=" + createdAt +
+                ", member=" + member +
+                '}';
+    }
+}

--- a/src/main/java/codesquad/javacafe/comment/entity/Comment.java
+++ b/src/main/java/codesquad/javacafe/comment/entity/Comment.java
@@ -1,0 +1,73 @@
+package codesquad.javacafe.comment.entity;
+
+import codesquad.javacafe.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+public class Comment {
+    private long id;
+    private long postId;
+    private String comment;
+    private LocalDateTime createdAt;
+    private Member member;
+
+    public Comment(){}
+    public Comment(long postId, String comment, Member member){
+        this.postId = postId;
+        this.comment = comment;
+        this.createdAt = LocalDateTime.now();
+        this.member = member;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public long getPostId() {
+        return postId;
+    }
+
+
+    public String getComment() {
+        return comment;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public void setPostId(long postId) {
+        this.postId = postId;
+    }
+
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    @Override
+    public String toString() {
+        return "Comment{" +
+                "id=" + id +
+                ", postId=" + postId +
+                ", comment='" + comment + '\'' +
+                ", createdAt=" + createdAt +
+                ", member=" + member +
+                '}';
+    }
+}

--- a/src/main/java/codesquad/javacafe/comment/repository/CommentRepository.java
+++ b/src/main/java/codesquad/javacafe/comment/repository/CommentRepository.java
@@ -3,6 +3,8 @@ package codesquad.javacafe.comment.repository;
 import codesquad.javacafe.comment.entity.Comment;
 import codesquad.javacafe.member.entity.Member;
 import codesquad.javacafe.member.repository.MemberRepository;
+import codesquad.javacafe.post.repository.PostRepository;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +53,7 @@ public class CommentRepository {
 
             return comment;
         } catch (SQLException exception) {
-            log.error("[SQLException] throw error when member save, Class Info = {}", MemberRepository.class);
+            log.error("[SQLException] throw error when member save, Class Info = {}", CommentRepository.class);
             throw new RuntimeException(exception);
         } finally {
             close(con, ps, null);
@@ -101,7 +103,7 @@ public class CommentRepository {
             }
 
         } catch (SQLException exception) {
-            log.error("[SQLException] throw error when findById, Class info = {}", MemberRepository.class);
+            log.error("[SQLException] throw error when findById, Class info = {}", CommentRepository.class);
             throw new RuntimeException(exception);
         } finally {
             close(con, ps, rs);
@@ -109,7 +111,7 @@ public class CommentRepository {
 
     }
 
-    public int delete(long commentId) {
+    public int deleteOne(long commentId) {
         var sql = "delete from comment where id = ?";
 
         Connection con = null;
@@ -123,7 +125,28 @@ public class CommentRepository {
 
             return result;
         } catch (SQLException exception) {
-            log.error("[SQLException] throw error when member save, Class Info = {}", MemberRepository.class);
+            log.error("[SQLException] throw error when member save, Class Info = {}", CommentRepository.class);
+            throw new RuntimeException(exception);
+        } finally {
+            close(con, ps, null);
+        }
+    }
+
+    public int deletePostComments(long postId) {
+        var sql = "delete from comment where post_id = ?";
+
+        Connection con = null;
+        PreparedStatement ps = null;
+
+        try {
+            con = getConnection();
+            ps = con.prepareStatement(sql);
+            ps.setLong(1, postId);
+            int result = ps.executeUpdate();
+
+            return result;
+        } catch (SQLException exception) {
+            log.error("[SQLException] throw error when member save, Class Info = {}", CommentRepository.class);
             throw new RuntimeException(exception);
         } finally {
             close(con, ps, null);

--- a/src/main/java/codesquad/javacafe/comment/repository/CommentRepository.java
+++ b/src/main/java/codesquad/javacafe/comment/repository/CommentRepository.java
@@ -63,7 +63,7 @@ public class CommentRepository {
 
     public List<Comment> findAll(long postId) {
         log.debug("[Comment Repository] post id = {}", postId);
-        var sql = "select c.id, c.post_id, c.comment_contents, c.comment_create, m.id, m.member_name" +
+        var sql = "select c.id as commentPk, c.post_id, c.comment_contents, c.comment_create, m.id as memberPk, m.member_name" +
                 " from comment c inner join member m" +
                 " on c.member_id = m.id where c.post_id = ?";
 
@@ -81,11 +81,11 @@ public class CommentRepository {
                 var commentList = new ArrayList<Comment>();
                 do {
                     var comment = new Comment();
-                    comment.setId(rs.getLong("c.id"));
+                    comment.setId(rs.getLong("commentPk"));
                     comment.setPostId(rs.getLong("post_id"));
                     comment.setComment(rs.getString("comment_contents"));
                     comment.setCreatedAt(rs.getTimestamp("comment_create").toLocalDateTime());
-                    var id = rs.getLong("m.id");
+                    var id = rs.getLong("memberPk");
                     var memberName = rs.getString("member_name");
                     var member = new Member();
                     member.setId(id);

--- a/src/main/java/codesquad/javacafe/comment/repository/CommentRepository.java
+++ b/src/main/java/codesquad/javacafe/comment/repository/CommentRepository.java
@@ -108,4 +108,25 @@ public class CommentRepository {
         }
 
     }
+
+    public int delete(long commentId) {
+        var sql = "delete from comment where id = ?";
+
+        Connection con = null;
+        PreparedStatement ps = null;
+
+        try {
+            con = getConnection();
+            ps = con.prepareStatement(sql);
+            ps.setLong(1, commentId);
+            int result = ps.executeUpdate();
+
+            return result;
+        } catch (SQLException exception) {
+            log.error("[SQLException] throw error when member save, Class Info = {}", MemberRepository.class);
+            throw new RuntimeException(exception);
+        } finally {
+            close(con, ps, null);
+        }
+    }
 }

--- a/src/main/java/codesquad/javacafe/comment/repository/CommentRepository.java
+++ b/src/main/java/codesquad/javacafe/comment/repository/CommentRepository.java
@@ -1,0 +1,111 @@
+package codesquad.javacafe.comment.repository;
+
+import codesquad.javacafe.comment.entity.Comment;
+import codesquad.javacafe.member.entity.Member;
+import codesquad.javacafe.member.repository.MemberRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static codesquad.javacafe.common.db.DBConnection.close;
+import static codesquad.javacafe.common.db.DBConnection.getConnection;
+
+public class CommentRepository {
+    private static final Logger log = LoggerFactory.getLogger(CommentRepository.class);
+    private static CommentRepository instance = new CommentRepository();
+
+    private CommentRepository() {
+
+    }
+
+    public static CommentRepository getInstance() {
+        return instance;
+    }
+
+    public Comment save(Comment comment) {
+        var sql = "insert into comment(post_id, member_id, comment_contents, comment_create)\n" +
+                "values (?,?,?,?)";
+        Connection con = null;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+
+        try {
+            con = getConnection();
+            ps = con.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+            ps.setLong(1, comment.getPostId());
+            ps.setLong(2, comment.getMember().getId());
+            ps.setString(3, comment.getComment());
+            ps.setTimestamp(4, Timestamp.valueOf(comment.getCreatedAt()));
+
+            ps.executeUpdate();
+
+            var generatedKeys = ps.getGeneratedKeys();
+            if (generatedKeys.next()) {
+                long pk = generatedKeys.getLong(1);
+                log.debug("[Comment PK] {}", pk);
+                comment.setId(pk);
+            }
+
+            return comment;
+        } catch (SQLException exception) {
+            log.error("[SQLException] throw error when member save, Class Info = {}", MemberRepository.class);
+            throw new RuntimeException(exception);
+        } finally {
+            close(con, ps, null);
+
+        }
+    }
+
+    public List<Comment> findAll(long postId) {
+        log.debug("[Comment Repository] post id = {}", postId);
+        var sql = "select c.id, c.post_id, c.comment_contents, c.comment_create, m.id, m.member_name" +
+                " from comment c inner join member m" +
+                " on c.member_id = m.id where c.post_id = ?";
+
+        Connection con = null;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+
+        try {
+            con = getConnection();
+            ps = con.prepareStatement(sql);
+            ps.setLong(1, postId);
+
+            rs = ps.executeQuery();
+            if (rs.next()) {
+                var commentList = new ArrayList<Comment>();
+                do {
+                    var comment = new Comment();
+                    comment.setId(rs.getLong("c.id"));
+                    comment.setPostId(rs.getLong("post_id"));
+                    comment.setComment(rs.getString("comment_contents"));
+                    comment.setCreatedAt(rs.getTimestamp("comment_create").toLocalDateTime());
+                    var id = rs.getLong("m.id");
+                    var memberName = rs.getString("member_name");
+                    var member = new Member();
+                    member.setId(id);
+                    member.setName(memberName);
+                    comment.setMember(member);
+
+                    commentList.add(comment);
+                } while (rs.next());
+
+                System.out.println(commentList);
+                return commentList;
+            } else {
+                log.info("[Comment Repository] 댓글 정보가 없습니다.");
+                return null;
+            }
+
+        } catch (SQLException exception) {
+            log.error("[SQLException] throw error when findById, Class info = {}", MemberRepository.class);
+            throw new RuntimeException(exception);
+        } finally {
+            close(con, ps, rs);
+        }
+
+    }
+}

--- a/src/main/java/codesquad/javacafe/comment/service/CommentService.java
+++ b/src/main/java/codesquad/javacafe/comment/service/CommentService.java
@@ -4,6 +4,7 @@ import codesquad.javacafe.comment.dto.request.CommentRequestDto;
 import codesquad.javacafe.comment.dto.response.CommentResponseDto;
 import codesquad.javacafe.comment.entity.Comment;
 import codesquad.javacafe.comment.repository.CommentRepository;
+import codesquad.javacafe.common.exception.ClientErrorCode;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,5 +27,12 @@ public class CommentService {
         return commentList.stream()
                 .map(CommentResponseDto::new)
                 .collect(Collectors.toList());
+    }
+
+    public void delete(long commentId) {
+        var result = CommentRepository.getInstance().delete(commentId);
+        if (result == 0) {
+            throw ClientErrorCode.COMMENT_IS_NULL.customException("comment id = " + commentId);
+        }
     }
 }

--- a/src/main/java/codesquad/javacafe/comment/service/CommentService.java
+++ b/src/main/java/codesquad/javacafe/comment/service/CommentService.java
@@ -7,6 +7,7 @@ import codesquad.javacafe.comment.repository.CommentRepository;
 import codesquad.javacafe.common.exception.ClientErrorCode;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class CommentService {
@@ -24,13 +25,16 @@ public class CommentService {
 
     public List<CommentResponseDto> getCommentList(long postId) {
         var commentList = CommentRepository.getInstance().findAll(postId);
+        if (Objects.isNull(commentList)) {
+            return null;
+        }
         return commentList.stream()
                 .map(CommentResponseDto::new)
                 .collect(Collectors.toList());
     }
 
     public void delete(long commentId) {
-        var result = CommentRepository.getInstance().delete(commentId);
+        var result = CommentRepository.getInstance().deleteOne(commentId);
         if (result == 0) {
             throw ClientErrorCode.COMMENT_IS_NULL.customException("comment id = " + commentId);
         }

--- a/src/main/java/codesquad/javacafe/comment/service/CommentService.java
+++ b/src/main/java/codesquad/javacafe/comment/service/CommentService.java
@@ -1,0 +1,30 @@
+package codesquad.javacafe.comment.service;
+
+import codesquad.javacafe.comment.dto.request.CommentRequestDto;
+import codesquad.javacafe.comment.dto.response.CommentResponseDto;
+import codesquad.javacafe.comment.entity.Comment;
+import codesquad.javacafe.comment.repository.CommentRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CommentService {
+    private static final CommentService instance = new CommentService();
+    private CommentService() {}
+    public static CommentService getInstance() {
+        return instance;
+    }
+
+    public CommentResponseDto save(CommentRequestDto commentDto) {
+        var comment = commentDto.toEntity();
+        var savedComment = CommentRepository.getInstance().save(comment);
+        return new CommentResponseDto(savedComment);
+    }
+
+    public List<CommentResponseDto> getCommentList(long postId) {
+        var commentList = CommentRepository.getInstance().findAll(postId);
+        return commentList.stream()
+                .map(CommentResponseDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/codesquad/javacafe/comment/util/LocalDateTimeSerializer.java
+++ b/src/main/java/codesquad/javacafe/comment/util/LocalDateTimeSerializer.java
@@ -1,0 +1,18 @@
+package codesquad.javacafe.comment.util;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateTimeSerializer implements JsonSerializer<LocalDateTime> {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    @Override
+    public JsonElement serialize(LocalDateTime src, Type typeOfSrc, JsonSerializationContext context) {
+        return context.serialize(src.format(formatter));
+    }
+}

--- a/src/main/java/codesquad/javacafe/common/db/DBConnection.java
+++ b/src/main/java/codesquad/javacafe/common/db/DBConnection.java
@@ -23,7 +23,6 @@ public class DBConnection {
 
     public static Connection getConnection() {
         try {
-           // Class.forName("com.mysql.jdbc.Driver");
             var connection = DriverManager.getConnection(URL, USERNAME, PASSWORD);
 
             log.info("[Connection]  connection info = {}, class = {}", connection, connection.getClass());

--- a/src/main/java/codesquad/javacafe/common/exception/ClientErrorCode.java
+++ b/src/main/java/codesquad/javacafe/common/exception/ClientErrorCode.java
@@ -10,7 +10,8 @@ public enum ClientErrorCode implements ErrorCode{
 	UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다."),
 	ACCESS_DENIED(HttpStatus.FORBIDDEN, "권한이 없는 사용자입니다."),
 	PARAMETER_IS_NULL(HttpStatus.BAD_REQUEST, "필요한 파라미터를 입력해주세요"),
-	POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "게시글 접근 권한이 없습니다.");
+	POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "게시글 접근 권한이 없습니다."),
+	COMMENT_IS_NULL(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/codesquad/javacafe/member/repository/MemberRepository.java
+++ b/src/main/java/codesquad/javacafe/member/repository/MemberRepository.java
@@ -1,7 +1,6 @@
 package codesquad.javacafe.member.repository;
 
 
-import codesquad.javacafe.member.dto.request.MemberCreateRequestDto;
 import codesquad.javacafe.member.dto.request.MemberUpdateRequestDto;
 import codesquad.javacafe.member.entity.Member;
 import org.slf4j.Logger;

--- a/src/main/java/codesquad/javacafe/post/cache/PostCache.java
+++ b/src/main/java/codesquad/javacafe/post/cache/PostCache.java
@@ -9,7 +9,7 @@ import java.util.*;
 
 public class PostCache {
     private static final PostCache instance = new PostCache();
-    private static final int MAX_ENTRIES = 100;
+    private static final int MAX_ENTRIES = 1000;
     // LRU 캐시로 사용
     private static final Map<Long, PostResponseDto> cache = new LinkedHashMap<>(MAX_ENTRIES, 0.75f,true) {
         @Override

--- a/src/main/java/codesquad/javacafe/post/repository/PostRepository.java
+++ b/src/main/java/codesquad/javacafe/post/repository/PostRepository.java
@@ -58,7 +58,7 @@ public class PostRepository {
 
             return post;
         } catch (SQLException exception) {
-            log.error("[SQLException] throw error when member save, Class Info = {}", MemberRepository.class);
+            log.error("[SQLException] throw error when member save, Class Info = {}", PostRepository.class);
             throw new RuntimeException(exception);
         } finally {
             close(con, ps, null);
@@ -100,7 +100,7 @@ public class PostRepository {
             }
 
         } catch (SQLException exception) {
-            log.error("[SQLException] throw error when findById, Class info = {}", MemberRepository.class);
+            log.error("[SQLException] throw error when findById, Class info = {}", PostRepository.class);
             throw new RuntimeException(exception);
         } finally {
             close(con, ps, rs);
@@ -140,7 +140,7 @@ public class PostRepository {
 
         } catch (SQLException exception) {
             exception.printStackTrace();
-            log.error("[SQLException] throw error when findById, Class info = {}", MemberRepository.class);
+            log.error("[SQLException] throw error when findById, Class info = {}", PostRepository.class);
             throw new RuntimeException(exception);
         } finally {
             close(con, ps, rs);
@@ -170,7 +170,7 @@ public class PostRepository {
 
             return result;
         } catch (SQLException exception) {
-            log.error("[SQLException] throw error when member save, Class Info = {}", MemberRepository.class);
+            log.error("[SQLException] throw error when member save, Class Info = {}", PostRepository.class);
             throw new RuntimeException(exception);
         } finally {
             close(con, ps, null);
@@ -192,7 +192,7 @@ public class PostRepository {
 
             return result;
         } catch (SQLException exception) {
-            log.error("[SQLException] throw error when member save, Class Info = {}", MemberRepository.class);
+            log.error("[SQLException] throw error when member save, Class Info = {}", PostRepository.class);
             throw new RuntimeException(exception);
         } finally {
             close(con, ps, null);

--- a/src/main/java/codesquad/javacafe/post/repository/PostRepository.java
+++ b/src/main/java/codesquad/javacafe/post/repository/PostRepository.java
@@ -28,8 +28,7 @@ public class PostRepository {
     }
 
 
-    public Post save(PostRequestDto postDto) {
-        Post post = postDto.toEntity();
+    public Post save(Post post) {
         var sql = "insert into post(post_writer, post_title, post_contents, post_create, member_id)\n" +
                 "values (?,?,?,?,?)";
 
@@ -147,8 +146,7 @@ public class PostRepository {
         }
     }
 
-    public int update(PostRequestDto postDto) {
-        Post post = postDto.toEntity();
+    public int update(Post post) {
         var sql = "update post set post_title = ?, post_contents =?\n" +
                 "where id = ? and member_id = ?";
 

--- a/src/main/java/codesquad/javacafe/post/service/PostService.java
+++ b/src/main/java/codesquad/javacafe/post/service/PostService.java
@@ -1,5 +1,6 @@
 package codesquad.javacafe.post.service;
 
+import codesquad.javacafe.comment.async.AsyncCommentDeleter;
 import codesquad.javacafe.common.exception.ClientErrorCode;
 import codesquad.javacafe.common.exception.ServerErrorCode;
 import codesquad.javacafe.post.dto.request.PostRequestDto;
@@ -10,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class PostService {
@@ -59,5 +61,6 @@ public class PostService {
         if (deleteResult == 0) {
             throw ClientErrorCode.POST_IS_NULL.customException("request post id = " + postId);
         }
+        AsyncCommentDeleter.getInstance().asyncDelete(postId, new AtomicInteger(0));
     }
 }

--- a/src/main/java/codesquad/javacafe/post/service/PostService.java
+++ b/src/main/java/codesquad/javacafe/post/service/PostService.java
@@ -5,6 +5,7 @@ import codesquad.javacafe.common.exception.ClientErrorCode;
 import codesquad.javacafe.common.exception.ServerErrorCode;
 import codesquad.javacafe.post.dto.request.PostRequestDto;
 import codesquad.javacafe.post.dto.response.PostResponseDto;
+import codesquad.javacafe.post.entity.Post;
 import codesquad.javacafe.post.repository.PostRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +27,8 @@ public class PostService {
     }
 
     public static void updatePost(PostRequestDto postDto) {
-        int update = PostRepository.getInstance().update(postDto);
+        var post = postDto.toEntity();
+        int update = PostRepository.getInstance().update(post);
         if (update == 0) {
             throw ClientErrorCode.POST_IS_NULL.customException("request post info = " + postDto);
         }
@@ -53,7 +55,8 @@ public class PostService {
     }
 
     public void createPost(PostRequestDto postDto) {
-        PostRepository.getInstance().save(postDto);
+        var post = postDto.toEntity();
+        PostRepository.getInstance().save(post);
     }
 
     public void deletePost(long postId) {

--- a/src/main/webapp/WEB-INF/qna/show.jsp
+++ b/src/main/webapp/WEB-INF/qna/show.jsp
@@ -129,20 +129,22 @@
 
 
         var template = '';
-        commentData.forEach(comment=> {
-            console.log(comment);
-            var addTemplate = $('#answerTemplate').html();
-            var formattedComment = addTemplate
-                .replace('{authorName}', comment.member.name) // Assuming memberId is used as authorName
-                .replace('{createdAt}', comment.createdAt)
-                .replace('{comment}', comment.comment.replaceAll(/\n/g, '<br>'))
-                .replaceAll('{commentId}', comment.id);
+        if(commentData != null){
 
-            template += formattedComment;
-        });
+            commentData.forEach(comment=> {
+                console.log(comment);
+                var addTemplate = $('#answerTemplate').html();
+                var formattedComment = addTemplate
+                    .replace('{authorName}', comment.member.name) // Assuming memberId is used as authorName
+                    .replace('{createdAt}', comment.createdAt)
+                    .replace('{comment}', comment.comment.replaceAll(/\n/g, '<br>'))
+                    .replaceAll('{commentId}', comment.id);
 
-        // console.log(template);
-        $('.qna-comment-slipp-articles').append(template);
+                template += formattedComment;
+            });
+
+            $('.qna-comment-slipp-articles').append(template);
+        }
     }
 </script>
 

--- a/src/main/webapp/WEB-INF/qna/show.jsp
+++ b/src/main/webapp/WEB-INF/qna/show.jsp
@@ -70,41 +70,10 @@
 
                 <div class="qna-comment">
                     <div class="qna-comment-slipp">
-                        <p class="qna-comment-count"><strong>2</strong>개의 의견</p>
+                        <p class="qna-comment-count"><strong></strong>댓글</p>
                         <div class="qna-comment-slipp-articles">
 
-                            <article class="article" id="answer-1405">
-                                <div class="article-header">
-                                    <div class="article-header-thumb">
-                                        <img src="https://graph.facebook.com/v2.3/1324855987/picture"
-                                             class="article-author-thumb" alt="">
-                                    </div>
-                                    <div class="article-header-text">
-                                        <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
-                                        <a href="#answer-1434" class="article-header-time" title="퍼머링크">
-                                            2016-01-12 14:06
-                                        </a>
-                                    </div>
-                                </div>
-                                <div class="article-doc comment-doc">
-                                    <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
-                                </div>
-                                <div class="article-util">
-                                    <ul class="article-util-list">
-                                        <li>
-                                            <a class="link-modify-article"
-                                               href="/questions/413/answers/1405/form">수정</a>
-                                        </li>
-                                        <li>
-                                            <form class="delete-answer-form" action="/questions/413/answers/1405"
-                                                  method="POST">
-                                                <input type="hidden" name="_method" value="DELETE">
-                                                <button type="submit" class="delete-answer-button">삭제</button>
-                                            </form>
-                                        </li>
-                                    </ul>
-                                </div>
-                            </article>
+
 
                         </div>
                         <form class="submit-write">
@@ -166,14 +135,13 @@
             var formattedComment = addTemplate
                 .replace('{authorName}', comment.member.name) // Assuming memberId is used as authorName
                 .replace('{createdAt}', comment.createdAt)
-                .replace('{comment}', comment.comment);
+                .replace('{comment}', comment.comment.replaceAll(/\n/g, '<br>'))
+                .replaceAll('{commentId}', comment.id);
 
             template += formattedComment;
         });
 
-        console.log(template);
-        // container.appendChild(template);
-        // $('#answer-1405').append(template);
+        // console.log(template);
         $('.qna-comment-slipp-articles').append(template);
     }
 </script>
@@ -197,7 +165,7 @@
             },
             error: function (request, status, error) {
                 console.log(error);
-
+                alert(error);
             }
         });
     }
@@ -205,11 +173,26 @@
 
 <%-- 게시글 삭제 --%>
 <script>
-    // $(".answer-write input[type='submit']").on("click", addAnswer);
-    $(".qna-comment-slipp-articles").on("click", ".delete-answer-form button[type='submit']", deleteAnswer);
 
-    function deleteAnswer(){
-        
+    function deleteComment(commentId){
+        console.log(commentId);
+        $.ajax({
+            url: '/ajax/comment',
+            type: 'DELETE',
+            dataType: 'json',
+            contentType: 'application/json',
+            timeout: 1500,
+            data: JSON.stringify({
+                commentId: commentId
+            }),
+            success: function () {
+                loadCommentList();
+            },
+            error: function (request, status, error) {
+                console.log(error);
+                alert(error);
+            }
+        });
     }
 </script>
 
@@ -230,10 +213,10 @@
         <div class="article-util">
             <ul class="article-util-list">
                 <li>
-                    <form class="delete-answer-form" action="#" method="POST">
+                    <form class="delete-answer-form">
                         <input type="hidden" name="_method" value="DELETE">
-                        <button type="submit" class="delete-answer-button" id="commentDelete">삭제</button>
                     </form>
+                    <button type="submit" class="delete-answer-button" id="commentDelete{commentId}" onclick="deleteComment({commentId})">삭제</button>
                 </li>
             </ul>
         </div>

--- a/src/main/webapp/WEB-INF/qna/show.jsp
+++ b/src/main/webapp/WEB-INF/qna/show.jsp
@@ -125,6 +125,7 @@
 </div>
 
 
+<%--게시글 생성 스크립트--%>
 <script>
     function postComment() {
         console.log("create comment called");
@@ -177,6 +178,7 @@
     }
 </script>
 
+<%-- 댓글 요청 스크립트--%>
 <script>
     window.onload = function () {
         loadCommentList();
@@ -201,6 +203,16 @@
     }
 </script>
 
+<%-- 게시글 삭제 --%>
+<script>
+    // $(".answer-write input[type='submit']").on("click", addAnswer);
+    $(".qna-comment-slipp-articles").on("click", ".delete-answer-form button[type='submit']", deleteAnswer);
+
+    function deleteAnswer(){
+        
+    }
+</script>
+
 <script type="text/template" id="answerTemplate">
     <article class="article">
         <div class="article-header">
@@ -218,12 +230,9 @@
         <div class="article-util">
             <ul class="article-util-list">
                 <li>
-                    <a class="link-modify-article" href="#">수정</a>
-                </li>
-                <li>
                     <form class="delete-answer-form" action="#" method="POST">
                         <input type="hidden" name="_method" value="DELETE">
-                        <button type="submit" class="delete-answer-button">삭제</button>
+                        <button type="submit" class="delete-answer-button" id="commentDelete">삭제</button>
                     </form>
                 </li>
             </ul>

--- a/src/main/webapp/WEB-INF/qna/show.jsp
+++ b/src/main/webapp/WEB-INF/qna/show.jsp
@@ -4,29 +4,32 @@
 
 <!DOCTYPE html>
 <html lang="kr">
-<jsp:include page="/common/header.jsp" />
+<jsp:include page="/common/header.jsp"/>
 <body>
-<jsp:include page="/common/topbar.jsp" />
-<jsp:include page="/common/navbar.jsp" />
+<jsp:include page="/common/topbar.jsp"/>
+<jsp:include page="/common/navbar.jsp"/>
 
 <div class="container" id="main">
     <div class="col-md-12 col-sm-12 col-lg-12">
         <div class="panel panel-default">
             <%
-                var post = (PostResponseDto)request.getAttribute("post");
+                var post = (PostResponseDto) request.getAttribute("post");
             %>
             <header class="qna-header">
-                <h2 class="qna-title"><%=post.getTitle()%></h2>
+                <h2 class="qna-title"><%=post.getTitle()%>
+                </h2>
             </header>
             <div class="content-main">
                 <article class="article">
                     <div class="article-header">
                         <div class="article-header-thumb">
-                            <img src="https://graph.facebook.com/v2.3/100000059371774/picture" class="article-author-thumb" alt="">
+                            <img src="https://graph.facebook.com/v2.3/100000059371774/picture"
+                                 class="article-author-thumb" alt="">
                         </div>
 
                         <div class="article-header-text">
-                            <a href="#" class="article-author-name"><%=post.getWriter()%></a>
+                            <a href="#" class="article-author-name"><%=post.getWriter()%>
+                            </a>
                             <a href="#" class="article-header-time" title="퍼머링크">
                                 <%=post.getCreatedAt()%>
                                 <i class="icon-link"></i>
@@ -36,9 +39,10 @@
                     <div class="article-doc">
                         <%
                             var contents = post.getContents().split("\n");
-                            for(var content : contents){
+                            for (var content : contents) {
 
-                        %><p><%=content%></p>
+                        %><p><%=content%>
+                    </p>
                         <%
                             }
                         %>
@@ -46,13 +50,14 @@
                     <div class="article-util">
                         <ul class="article-util-list">
                             <li>
-                                <a class="link-modify-article" id="updateButton" href="/api/post/update?postId=<%=post.getId()%>">수정</a>
+                                <a class="link-modify-article" id="updateButton"
+                                   href="/api/post/update?postId=<%=post.getId()%>">수정</a>
                             </li>
                             <li>
                                 <form class="form-delete" action="/api/post" method="POST">
                                     <input type="hidden" name="method" value="DELETE">
-                                    <input type="hidden" name="postId" value="<%=post.getId()%>">
-                                    <input type="hidden" name="memberId" value="<%=post.getMemberId()%>">
+                                    <input type="hidden" name="postId" id="postId" value="<%=post.getId()%>">
+                                    <input type="hidden" name="memberId" id="memberId" value="<%=post.getMemberId()%>">
                                     <button class="link-delete-article" type="submit">삭제</button>
                                 </form>
                             </li>
@@ -63,83 +68,138 @@
                     </div>
                 </article>
 
-<%--                <div class="qna-comment">--%>
-<%--                    <div class="qna-comment-slipp">--%>
-<%--                        <p class="qna-comment-count"><strong>2</strong>개의 의견</p>--%>
-<%--                        <div class="qna-comment-slipp-articles">--%>
+                <div class="qna-comment">
+                    <div class="qna-comment-slipp">
+                        <p class="qna-comment-count"><strong>2</strong>개의 의견</p>
+                        <div class="qna-comment-slipp-articles">
 
-<%--                            <article class="article" id="answer-1405">--%>
-<%--                                <div class="article-header">--%>
-<%--                                    <div class="article-header-thumb">--%>
-<%--                                        <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">--%>
-<%--                                    </div>--%>
-<%--                                    <div class="article-header-text">--%>
-<%--                                        <a href="/users/1/자바지기" class="article-author-name">자바지기</a>--%>
-<%--                                        <a href="#answer-1434" class="article-header-time" title="퍼머링크">--%>
-<%--                                            2016-01-12 14:06--%>
-<%--                                        </a>--%>
-<%--                                    </div>--%>
-<%--                                </div>--%>
-<%--                                <div class="article-doc comment-doc">--%>
-<%--                                    <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>--%>
-<%--                                </div>--%>
-<%--                                <div class="article-util">--%>
-<%--                                    <ul class="article-util-list">--%>
-<%--                                        <li>--%>
-<%--                                            <a class="link-modify-article" href="/questions/413/answers/1405/form">수정</a>--%>
-<%--                                        </li>--%>
-<%--                                        <li>--%>
-<%--                                            <form class="delete-answer-form" action="/questions/413/answers/1405" method="POST">--%>
-<%--                                                <input type="hidden" name="_method" value="DELETE">--%>
-<%--                                                <button type="submit" class="delete-answer-button">삭제</button>--%>
-<%--                                            </form>--%>
-<%--                                        </li>--%>
-<%--                                    </ul>--%>
-<%--                                </div>--%>
-<%--                            </article>--%>
-<%--                            <article class="article" id="answer-1406">--%>
-<%--                                <div class="article-header">--%>
-<%--                                    <div class="article-header-thumb">--%>
-<%--                                        <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">--%>
-<%--                                    </div>--%>
-<%--                                    <div class="article-header-text">--%>
-<%--                                        <a href="/users/1/자바지기" class="article-author-name">자바지기</a>--%>
-<%--                                        <a href="#answer-1434" class="article-header-time" title="퍼머링크">--%>
-<%--                                            2016-01-12 14:06--%>
-<%--                                        </a>--%>
-<%--                                    </div>--%>
-<%--                                </div>--%>
-<%--                                <div class="article-doc comment-doc">--%>
-<%--                                    <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>--%>
-<%--                                </div>--%>
-<%--                                <div class="article-util">--%>
-<%--                                    <ul class="article-util-list">--%>
-<%--                                        <li>--%>
-<%--                                            <a class="link-modify-article" href="/questions/413/answers/1405/form">수정</a>--%>
-<%--                                        </li>--%>
-<%--                                        <li>--%>
-<%--                                            <form class="form-delete" action="/questions/413/answers/1405" method="POST">--%>
-<%--                                                <input type="hidden" name="_method" value="DELETE">--%>
-<%--                                                <button type="submit" class="delete-answer-button">삭제</button>--%>
-<%--                                            </form>--%>
-<%--                                        </li>--%>
-<%--                                    </ul>--%>
-<%--                                </div>--%>
-<%--                            </article>--%>
-<%--                            <form class="submit-write">--%>
-<%--                                <div class="form-group" style="padding:14px;">--%>
-<%--                                    <textarea class="form-control" placeholder="Update your status"></textarea>--%>
-<%--                                </div>--%>
-<%--                                <button class="btn btn-success pull-right" type="button">답변하기</button>--%>
-<%--                                <div class="clearfix"></div>--%>
-<%--                            </form>--%>
-<%--                        </div>--%>
-<%--                    </div>--%>
-<%--                </div>--%>
+                            <article class="article" id="answer-1405">
+                                <div class="article-header">
+                                    <div class="article-header-thumb">
+                                        <img src="https://graph.facebook.com/v2.3/1324855987/picture"
+                                             class="article-author-thumb" alt="">
+                                    </div>
+                                    <div class="article-header-text">
+                                        <a href="/users/1/자바지기" class="article-author-name">자바지기</a>
+                                        <a href="#answer-1434" class="article-header-time" title="퍼머링크">
+                                            2016-01-12 14:06
+                                        </a>
+                                    </div>
+                                </div>
+                                <div class="article-doc comment-doc">
+                                    <p>이 글만으로는 원인 파악하기 힘들겠다. 소스 코드와 설정을 단순화해서 공유해 주면 같이 디버깅해줄 수도 있겠다.</p>
+                                </div>
+                                <div class="article-util">
+                                    <ul class="article-util-list">
+                                        <li>
+                                            <a class="link-modify-article"
+                                               href="/questions/413/answers/1405/form">수정</a>
+                                        </li>
+                                        <li>
+                                            <form class="delete-answer-form" action="/questions/413/answers/1405"
+                                                  method="POST">
+                                                <input type="hidden" name="_method" value="DELETE">
+                                                <button type="submit" class="delete-answer-button">삭제</button>
+                                            </form>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </article>
+
+                        </div>
+                        <form class="submit-write">
+                            <div class="form-group" style="padding:14px;">
+                                    <textarea class="form-control" id="comment"
+                                              placeholder="Update your status"></textarea>
+                            </div>
+                            <button class="btn btn-success pull-right" id="commentButton" type="button"
+                                    onclick="postComment()">답변하기
+                            </button>
+                            <div class="clearfix"></div>
+                        </form>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 </div>
+
+
+<script>
+    function postComment() {
+        console.log("create comment called");
+        $.ajax({
+            url: '/ajax/comment',
+            type: 'POST',
+            dataType: 'json',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                postId: $('#postId').val(),
+                memberId: $('#memberId').val(),
+                comment: $('#comment').val()
+            }),
+            timeout: 1500,
+            success: function (data) {
+                console.log(data);
+                loadCommentList();
+            },
+            error: function (request, status, error) {
+
+                console.log(error);
+            }
+        });
+
+        document.getElementById('comment').value = '';
+    }
+
+    function addCommentToPage(commentData) {
+        const container = document.querySelector('.qna-comment-slipp-articles');
+        container.innerHTML = '';
+
+
+
+        var template = '';
+        commentData.forEach(comment=> {
+            console.log(comment);
+            var addTemplate = $('#answerTemplate').html();
+            var formattedComment = addTemplate
+                .replace('{authorName}', comment.member.name) // Assuming memberId is used as authorName
+                .replace('{createdAt}', comment.createdAt)
+                .replace('{comment}', comment.comment);
+
+            template += formattedComment;
+        });
+
+        console.log(template);
+        // container.appendChild(template);
+        // $('#answer-1405').append(template);
+        $('.qna-comment-slipp-articles').append(template);
+    }
+</script>
+
+<script>
+    window.onload = function () {
+        loadCommentList();
+    }
+
+    function loadCommentList(){
+        $.ajax({
+            url: '/ajax/comment?postId='+$('#postId').val(),
+            type: 'GET',
+            dataType: 'json',
+            contentType: 'application/json',
+            timeout: 1500,
+            success: function (data) {
+                console.log(data);
+                addCommentToPage(data);
+            },
+            error: function (request, status, error) {
+                console.log(error);
+
+            }
+        });
+    }
+</script>
 
 <script type="text/template" id="answerTemplate">
     <article class="article">
@@ -148,12 +208,12 @@
                 <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
             </div>
             <div class="article-header-text">
-                <a href="#" class="article-author-name">{0}</a>
-                <div class="article-header-time">{1}</div>
+                <a href="#" class="article-author-name">{authorName}</a>
+                <div class="article-header-time">{createdAt}</div>
             </div>
         </div>
         <div class="article-doc comment-doc">
-            {2}
+            {comment}
         </div>
         <div class="article-util">
             <ul class="article-util-list">
@@ -170,7 +230,6 @@
         </div>
     </article>
 </script>
-
 
 <!-- script references -->
 <script src="<%= request.getContextPath() %>/js/jquery-2.2.0.min.js"></script>

--- a/src/test/java/codesquad/javacafe/auth/controller/AuthControllerTest.java
+++ b/src/test/java/codesquad/javacafe/auth/controller/AuthControllerTest.java
@@ -56,12 +56,29 @@ public class AuthControllerTest {
                 "member_name VARCHAR(255)" +
                 ")";
         statement.execute(createTableSql);
+
+        createTableSql = "CREATE TABLE if not exists post (" +
+            "id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+            "post_writer VARCHAR(255), " +
+            "post_title VARCHAR(255), " +
+            "post_contents TEXT, " +
+            "post_create TIMESTAMP," +
+            "member_id BIGINT NOT NULL" +
+            ")";
+        statement.execute(createTableSql);
+
         statement.close();
         connection.close();
     }
 
     private void clearTable() throws SQLException {
         var sql = "DELETE FROM member";
+        try (var statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+
+
+        sql = "DELETE FROM post";
         try (var statement = connection.createStatement()) {
             statement.execute(sql);
         }
@@ -99,7 +116,7 @@ public class AuthControllerTest {
         authController.doProcess(request, response);
 
         assertNotNull(request.getSession().getAttribute("loginInfo"));
-        assertEquals("/WEB-INF/user/list.jsp", ((CustomHttpServletResponse) response).getForwardedUrl());
+        assertEquals("/WEB-INF/index.jsp", ((CustomHttpServletResponse) response).getForwardedUrl());
     }
 
     @Test

--- a/src/test/java/codesquad/javacafe/comment/controller/CommentControllerTest.java
+++ b/src/test/java/codesquad/javacafe/comment/controller/CommentControllerTest.java
@@ -1,0 +1,207 @@
+package codesquad.javacafe.comment.controller;
+
+import codesquad.javacafe.comment.dto.request.CommentRequestDto;
+import codesquad.javacafe.comment.dto.response.CommentResponseDto;
+import codesquad.javacafe.comment.entity.Comment;
+import codesquad.javacafe.comment.repository.CommentRepository;
+import codesquad.javacafe.comment.service.CommentService;
+import codesquad.javacafe.common.db.DBConnection;
+import codesquad.javacafe.common.exception.ClientErrorCode;
+import codesquad.javacafe.common.exception.CustomException;
+import codesquad.javacafe.common.session.MemberInfo;
+import codesquad.javacafe.member.entity.Member;
+import codesquad.javacafe.member.repository.MemberRepository;
+import codesquad.javacafe.post.dto.request.PostRequestDto;
+import codesquad.javacafe.post.entity.Post;
+import codesquad.javacafe.post.repository.PostRepository;
+import codesquad.javacafe.util.CustomHttpServletRequest;
+import codesquad.javacafe.util.CustomHttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CommentControllerTest {
+	private static CommentController commentController;
+	private static Connection connection;
+	private static long memberId;
+	private static long postId;
+
+	@BeforeAll
+	static void setUp() throws SQLException {
+		commentController = new CommentController();
+		DBConnection.setConnectionInfo("jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE", "sa", "");
+		connection = DBConnection.getConnection();
+		createTable();
+	}
+
+	@BeforeEach
+	void init(){
+		Member member = new Member("user1", "password", "User One");
+		MemberRepository.getInstance().save(member);
+		memberId = member.getId();
+		Map<String, String[]> body = new HashMap<>();
+		body.put("title", new String[]{"title1"});
+		body.put("contents", new String[]{"contents1"});
+		PostRequestDto postDto = new PostRequestDto(body);
+		postDto.setWriter("User One");
+		postDto.setMemberId(memberId);
+		Post savePost = PostRepository.getInstance().save(postDto.toEntity());
+		postId = savePost.getId();
+	}
+
+	@AfterEach
+	void afterEach() throws SQLException {
+		clearTable();
+	}
+
+	static void createTable() throws SQLException {
+		Connection connection = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
+		Statement statement = connection.createStatement();
+		// Create the comment table
+		String createTableSql = "CREATE TABLE if not exists comment (" +
+			"id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+			"post_id BIGINT NOT NULL, " +
+			"member_id BIGINT NOT NULL, " +
+			"comment_contents TEXT, " +
+			"comment_create TIMESTAMP" +
+			")";
+		statement.execute(createTableSql);
+
+		String createMemberTableSql = "CREATE TABLE if not exists member (" +
+			"id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+			"member_id VARCHAR(255), " +
+			"member_password VARCHAR(255), " +
+			"member_name VARCHAR(255)" +
+			")";
+		statement.execute(createMemberTableSql);
+
+		String createPostTableSql = "CREATE TABLE if not exists post (" +
+			"id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+			"post_writer VARCHAR(255), " +
+			"post_title VARCHAR(255), " +
+			"post_contents TEXT, " +
+			"post_create TIMESTAMP," +
+			"member_id BIGINT NOT NULL" +
+			")";
+		statement.execute(createPostTableSql);
+
+
+		statement.close();
+		connection.close();
+	}
+
+	private void clearTable() throws SQLException {
+		var sql = "DELETE FROM comment";
+		try (var statement = connection.createStatement()) {
+			statement.execute(sql);
+		}
+
+		sql = "DELETE FROM post";
+		try (var statement = connection.createStatement()) {
+			statement.execute(sql);
+		}
+
+		sql = "DELETE FROM member";
+		try (var statement = connection.createStatement()) {
+			statement.execute(sql);
+		}
+	}
+
+	@Test
+	public void testDoProcessGet() throws ServletException, IOException {
+		// Insert a comment into the database
+		Map<String, Object> data = new HashMap<>();
+		data.put("postId", postId);
+		data.put("memberId", memberId);
+		data.put("comment", "This is a comment");
+		CommentRequestDto commentDto = new CommentRequestDto(data);
+		CommentService.getInstance().save(commentDto);
+
+		// Simulate GET request with query parameters
+		HttpServletRequest request = new CustomHttpServletRequest();
+		HttpServletResponse response = new CustomHttpServletResponse();
+		((CustomHttpServletRequest) request).setMethod("GET");
+		((CustomHttpServletRequest) request).addParameter("postId", postId+"");
+		request.setAttribute("userId", "user1");
+		request.getSession().setAttribute("loginInfo", new MemberInfo(memberId, "user1", "User One"));
+
+		commentController.doProcess(request, response);
+
+		List<Comment> comments = CommentRepository.getInstance().findAll(postId);
+		assertNotNull(comments);
+		assertFalse(comments.isEmpty());
+		assertEquals("This is a comment", comments.get(0).getComment());
+	}
+
+	@Test
+	public void testDoProcessPost() throws ServletException, IOException {
+		// Simulate POST request
+		HttpServletRequest request = new CustomHttpServletRequest();
+		HttpServletResponse response = new CustomHttpServletResponse();
+		((CustomHttpServletRequest) request).setMethod("POST");
+		((CustomHttpServletRequest) request).setBody("{\"postId\": 1, \"memberId\": " + memberId + ", \"comment\": \"This is a test comment\"}");
+		request.getSession().setAttribute("loginInfo", new MemberInfo(memberId, "user1", "User One"));
+
+		commentController.doProcess(request, response);
+
+		assertEquals(HttpServletResponse.SC_CREATED, response.getStatus());
+		CommentResponseDto comment = CommentService.getInstance().getCommentList(1L).get(0);
+		assertNotNull(comment);
+		assertEquals("This is a test comment", comment.getComment());
+	}
+
+	@Test
+	public void testDoProcessDelete() throws ServletException, IOException {
+		// Insert a comment into the database
+		Map<String, Object> data = new HashMap<>();
+		data.put("postId", postId);
+		data.put("memberId", memberId);
+		data.put("comment", "This is a comment to delete");
+		CommentRequestDto commentDto = new CommentRequestDto(data);
+		CommentResponseDto savedComment = CommentService.getInstance().save(commentDto);
+
+		// Simulate DELETE request
+		HttpServletRequest request = new CustomHttpServletRequest();
+		HttpServletResponse response = new CustomHttpServletResponse();
+		((CustomHttpServletRequest) request).setMethod("DELETE");
+		((CustomHttpServletRequest) request).setBody("{\"commentId\": " + savedComment.getId() + "}");
+		request.getSession().setAttribute("loginInfo", new MemberInfo(memberId, "user1", "User One"));
+
+		commentController.doProcess(request, response);
+
+		assertEquals(HttpServletResponse.SC_NO_CONTENT, response.getStatus());
+		List<CommentResponseDto> comments = CommentService.getInstance().getCommentList(1L);
+		assertNull(comments);
+	}
+
+	@Test
+	public void testDoProcessDeleteWithNonExistentCommentId() throws ServletException, IOException {
+		// Simulate DELETE request with non-existent comment ID
+		HttpServletRequest request = new CustomHttpServletRequest();
+		HttpServletResponse response = new CustomHttpServletResponse();
+		((CustomHttpServletRequest) request).setMethod("DELETE");
+		((CustomHttpServletRequest) request).setBody("{\"commentId\": 9999}"); // Non-existent comment ID
+		request.getSession().setAttribute("loginInfo", new MemberInfo(memberId, "user1", "User One"));
+
+		CustomException exception = assertThrows(CustomException.class, () -> {
+			commentController.doProcess(request, response);
+		});
+
+		assertEquals(ClientErrorCode.PARAMETER_IS_NULL.getHttpStatus(), exception.getHttpStatus());
+	}
+}

--- a/src/test/java/codesquad/javacafe/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/codesquad/javacafe/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,204 @@
+package codesquad.javacafe.comment.repository;
+
+import codesquad.javacafe.comment.entity.Comment;
+import codesquad.javacafe.common.db.DBConnection;
+import codesquad.javacafe.member.entity.Member;
+import codesquad.javacafe.member.repository.MemberRepository;
+import codesquad.javacafe.post.entity.Post;
+import codesquad.javacafe.post.repository.PostRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CommentRepositoryTest {
+	private static CommentRepository commentRepository;
+	private static Connection connection;
+	private static long memberId;
+	private static long postId;
+
+	@BeforeAll
+	static void setUp() throws SQLException {
+		commentRepository = CommentRepository.getInstance();
+		DBConnection.setConnectionInfo("jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE", "sa", "");
+		connection = DBConnection.getConnection();
+		createTable();
+	}
+
+	@BeforeEach
+	void init() {
+		Member member = new Member("user1", "password", "User One");
+		MemberRepository.getInstance().save(member);
+		memberId = member.getId();
+
+		Post post = new Post();
+		post.setWriter("User One");
+		post.setTitle("title1");
+		post.setContents("contents1");
+		post.setMemberId(memberId);
+		post.setCreatedAt(LocalDateTime.now());
+		PostRepository.getInstance().save(post);
+		postId = post.getId();
+	}
+
+	@AfterEach
+	void afterEach() throws SQLException {
+		clearTable();
+	}
+
+	static void createTable() throws SQLException {
+		Connection connection = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
+		Statement statement = connection.createStatement();
+
+		String createCommentTableSql = "CREATE TABLE if not exists comment (" +
+			"id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+			"post_id BIGINT NOT NULL, " +
+			"member_id BIGINT NOT NULL, " +
+			"comment_contents TEXT, " +
+			"comment_create TIMESTAMP" +
+			")";
+		statement.execute(createCommentTableSql);
+
+		String createMemberTableSql = "CREATE TABLE if not exists member (" +
+			"id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+			"member_id VARCHAR(255), " +
+			"member_password VARCHAR(255), " +
+			"member_name VARCHAR(255)" +
+			")";
+		statement.execute(createMemberTableSql);
+
+		String createPostTableSql = "CREATE TABLE if not exists post (" +
+			"id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+			"post_writer VARCHAR(255), " +
+			"post_title VARCHAR(255), " +
+			"post_contents TEXT, " +
+			"post_create TIMESTAMP," +
+			"member_id BIGINT NOT NULL" +
+			")";
+		statement.execute(createPostTableSql);
+
+		statement.close();
+		connection.close();
+	}
+
+	private void clearTable() throws SQLException {
+		var sql = "DELETE FROM comment";
+		try (var statement = connection.createStatement()) {
+			statement.execute(sql);
+		}
+
+		sql = "DELETE FROM post";
+		try (var statement = connection.createStatement()) {
+			statement.execute(sql);
+		}
+
+		sql = "DELETE FROM member";
+		try (var statement = connection.createStatement()) {
+			statement.execute(sql);
+		}
+	}
+
+	@Test
+	public void testSaveComment() {
+		Comment comment = new Comment();
+		comment.setPostId(postId);
+		Member member = new Member();
+		member.setId(memberId);
+		member.setName("User One");
+		comment.setMember(member);
+		comment.setComment("This is a test comment");
+		comment.setCreatedAt(LocalDateTime.now());
+
+		Comment savedComment = commentRepository.save(comment);
+
+		assertNotNull(savedComment.getId());
+		assertEquals("This is a test comment", savedComment.getComment());
+	}
+
+	@Test
+	public void testFindAllComments() {
+		Comment comment1 = new Comment();
+		comment1.setPostId(postId);
+		Member member = new Member();
+		member.setId(memberId);
+		member.setName("User One");
+		comment1.setMember(member);
+		comment1.setComment("First comment");
+		comment1.setCreatedAt(LocalDateTime.now());
+		commentRepository.save(comment1);
+
+		Comment comment2 = new Comment();
+		comment2.setPostId(postId);
+
+		Member member2 = new Member("user2", "password", "User Two");
+		MemberRepository.getInstance().save(member2);
+		comment2.setMember(member2);
+		comment2.setComment("Second comment");
+		comment2.setCreatedAt(LocalDateTime.now());
+		commentRepository.save(comment2);
+
+		List<Comment> comments = commentRepository.findAll(postId);
+
+		assertNotNull(comments);
+		assertEquals(2, comments.size());
+		assertEquals("First comment", comments.get(0).getComment());
+		assertEquals("Second comment", comments.get(1).getComment());
+	}
+
+	@Test
+	public void testDeleteComment() {
+		Comment comment = new Comment();
+		comment.setPostId(postId);
+		Member member = new Member();
+		member.setId(memberId);
+		member.setName("User One");
+		comment.setMember(member);
+		comment.setComment("Comment to delete");
+		comment.setCreatedAt(LocalDateTime.now());
+		Comment savedComment = commentRepository.save(comment);
+
+		int result = commentRepository.deleteOne(savedComment.getId());
+
+		assertEquals(1, result);
+		List<Comment> comments = commentRepository.findAll(postId);
+		assertNull(comments);
+	}
+
+	@Test
+	public void testDeletePostComments() {
+		Comment comment1 = new Comment();
+		comment1.setPostId(postId);
+		Member member = new Member();
+		member.setId(memberId);
+		member.setName("User One");
+		comment1.setMember(member);
+		comment1.setComment("First comment");
+		comment1.setCreatedAt(LocalDateTime.now());
+		commentRepository.save(comment1);
+
+
+		Comment comment2 = new Comment();
+		comment2.setPostId(postId);
+		Member member2 = new Member("user2", "password", "User Two");
+		MemberRepository.getInstance().save(member);
+		comment2.setMember(member2);
+		comment2.setComment("Second comment");
+		comment2.setCreatedAt(LocalDateTime.now());
+		commentRepository.save(comment2);
+
+		int result = commentRepository.deletePostComments(postId);
+
+		assertEquals(2, result);
+		List<Comment> comments = commentRepository.findAll(postId);
+		assertNull(comments);
+	}
+}

--- a/src/test/java/codesquad/javacafe/comment/service/CommentServiceTest.java
+++ b/src/test/java/codesquad/javacafe/comment/service/CommentServiceTest.java
@@ -1,0 +1,176 @@
+package codesquad.javacafe.comment.service;
+
+import codesquad.javacafe.comment.dto.request.CommentRequestDto;
+import codesquad.javacafe.comment.dto.response.CommentResponseDto;
+import codesquad.javacafe.common.db.DBConnection;
+import codesquad.javacafe.common.exception.ClientErrorCode;
+import codesquad.javacafe.common.exception.CustomException;
+import codesquad.javacafe.member.entity.Member;
+import codesquad.javacafe.member.repository.MemberRepository;
+import codesquad.javacafe.post.entity.Post;
+import codesquad.javacafe.post.repository.PostRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CommentServiceTest {
+	private static CommentService commentService;
+	private static Connection connection;
+	private static long memberId;
+	private static long postId;
+
+	@BeforeAll
+	static void setUp() throws SQLException {
+		commentService = CommentService.getInstance();
+		DBConnection.setConnectionInfo("jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE", "sa", "");
+		connection = DBConnection.getConnection();
+		createTable();
+	}
+
+	@BeforeEach
+	void init() {
+		Member member = new Member("user1", "password", "User One");
+		MemberRepository.getInstance().save(member);
+		memberId = member.getId();
+
+		Post post = new Post();
+		post.setWriter("User One");
+		post.setTitle("title1");
+		post.setContents("contents1");
+		post.setMemberId(memberId);
+		post.setCreatedAt(LocalDateTime.now());
+		PostRepository.getInstance().save(post);
+		postId = post.getId();
+	}
+
+	@AfterEach
+	void afterEach() throws SQLException {
+		clearTable();
+	}
+
+	static void createTable() throws SQLException {
+		Connection connection = DriverManager.getConnection("jdbc:h2:mem:testdb", "sa", "");
+		Statement statement = connection.createStatement();
+
+		String createCommentTableSql = "CREATE TABLE if not exists comment (" +
+			"id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+			"post_id BIGINT NOT NULL, " +
+			"member_id BIGINT NOT NULL, " +
+			"comment_contents TEXT, " +
+			"comment_create TIMESTAMP" +
+			")";
+		statement.execute(createCommentTableSql);
+
+		String createMemberTableSql = "CREATE TABLE if not exists member (" +
+			"id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+			"member_id VARCHAR(255), " +
+			"member_password VARCHAR(255), " +
+			"member_name VARCHAR(255)" +
+			")";
+		statement.execute(createMemberTableSql);
+
+		String createPostTableSql = "CREATE TABLE if not exists post (" +
+			"id BIGINT AUTO_INCREMENT PRIMARY KEY, " +
+			"post_writer VARCHAR(255), " +
+			"post_title VARCHAR(255), " +
+			"post_contents TEXT, " +
+			"post_create TIMESTAMP," +
+			"member_id BIGINT NOT NULL" +
+			")";
+		statement.execute(createPostTableSql);
+
+		statement.close();
+		connection.close();
+	}
+
+	private void clearTable() throws SQLException {
+		var sql = "DELETE FROM comment";
+		try (var statement = connection.createStatement()) {
+			statement.execute(sql);
+		}
+
+		sql = "DELETE FROM post";
+		try (var statement = connection.createStatement()) {
+			statement.execute(sql);
+		}
+
+		sql = "DELETE FROM member";
+		try (var statement = connection.createStatement()) {
+			statement.execute(sql);
+		}
+	}
+
+	@Test
+	public void testSaveComment() {
+		Map<String, Object> data = new HashMap<>();
+		data.put("postId", postId);
+		data.put("memberId", memberId);
+		data.put("comment", "This is a test comment");
+		CommentRequestDto commentDto = new CommentRequestDto(data);
+
+		CommentResponseDto savedComment = commentService.save(commentDto);
+
+		assertNotNull(savedComment.getId());
+		assertEquals("This is a test comment", savedComment.getComment());
+	}
+
+	@Test
+	public void testGetCommentList() {
+		Map<String, Object> data1 = new HashMap<>();
+		data1.put("postId", postId);
+		data1.put("memberId", memberId);
+		data1.put("comment", "First comment");
+		CommentRequestDto commentDto1 = new CommentRequestDto(data1);
+		commentService.save(commentDto1);
+
+		Map<String, Object> data2 = new HashMap<>();
+		data2.put("postId", postId);
+		data2.put("memberId", memberId);
+		data2.put("comment", "Second comment");
+		CommentRequestDto commentDto2 = new CommentRequestDto(data2);
+		commentService.save(commentDto2);
+
+		List<CommentResponseDto> comments = commentService.getCommentList(postId);
+
+		assertNotNull(comments);
+		assertEquals(2, comments.size());
+		assertEquals("First comment", comments.get(0).getComment());
+		assertEquals("Second comment", comments.get(1).getComment());
+	}
+
+	@Test
+	public void testDeleteComment() {
+		Map<String, Object> data = new HashMap<>();
+		data.put("postId", postId);
+		data.put("memberId", memberId);
+		data.put("comment", "Comment to delete");
+		CommentRequestDto commentDto = new CommentRequestDto(data);
+		CommentResponseDto savedComment = commentService.save(commentDto);
+
+		commentService.delete(savedComment.getId());
+
+		List<CommentResponseDto> comments = commentService.getCommentList(postId);
+		assertNull(comments);
+	}
+
+	@Test
+	public void testDeleteNonExistentComment() {
+		CustomException exception = assertThrows(CustomException.class, () -> {
+			commentService.delete(9999L); // Non-existent comment ID
+		});
+
+		assertEquals(ClientErrorCode.COMMENT_IS_NULL.getHttpStatus(), exception.getHttpStatus());
+	}
+}

--- a/src/test/java/codesquad/javacafe/post/cache/PostCacheTest.java
+++ b/src/test/java/codesquad/javacafe/post/cache/PostCacheTest.java
@@ -63,7 +63,7 @@ class PostCacheTest {
             body.put("memberId", new String[]{"1"});
             PostRequestDto postDto = new PostRequestDto(body);
             postDto.setMemberId(memberId);
-            Post save = PostRepository.getInstance().save(postDto);
+            Post save = PostRepository.getInstance().save(postDto.toEntity());
             list.add(save.getId());
         }
 

--- a/src/test/java/codesquad/javacafe/post/cache/PostCacheTest.java
+++ b/src/test/java/codesquad/javacafe/post/cache/PostCacheTest.java
@@ -56,7 +56,7 @@ class PostCacheTest {
         request.getSession().setAttribute("loginInfo", new MemberInfo(1, "user1", "User One"));
 
         List<Long> list = new ArrayList<>();
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 10000; i++) {
             body.put("writer", new String[]{"writer1"});
             body.put("title", new String[]{"title1"});
             body.put("contents", new String[]{"contents1"});
@@ -68,7 +68,7 @@ class PostCacheTest {
         }
 
         long notCacheStart = System.currentTimeMillis();
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 10000; i++) {
             ((CustomHttpServletRequest) request).setMethod("GET");
             ((CustomHttpServletRequest) request).addParameter("postId",  + list.get(i)+ "");
             System.out.println(request.getAttribute("userId"));
@@ -81,7 +81,7 @@ class PostCacheTest {
 
 
         long cacheHitStart = System.currentTimeMillis();
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 10000; i++) {
             ((CustomHttpServletRequest) request).setMethod("GET");
             ((CustomHttpServletRequest) request).addParameter("postId",  + list.get(i)+ "");
             postController.doProcess(request, response);
@@ -123,7 +123,7 @@ class PostCacheTest {
         expectedList = List.of(0L, 1L, 3L, 4L, 2L);
         assertEquals(expectedList,list);
 
-        for (int i = 5; i <= 100; i++) {
+        for (int i = 5; i <= 1000; i++) {
             PostResponseDto postResponseDto = new PostResponseDto(i, "writer" + i, "title" + i, "contents" + i, LocalDateTime.now());
             PostCache.getInstance().set(i, postResponseDto);
         }

--- a/src/test/java/codesquad/javacafe/post/controller/PostControllerTest.java
+++ b/src/test/java/codesquad/javacafe/post/controller/PostControllerTest.java
@@ -102,7 +102,7 @@ public class PostControllerTest {
         PostRequestDto postDto = new PostRequestDto(body);
         postDto.setWriter("User One");
         postDto.setMemberId(memberId);
-        Post savePost = PostRepository.getInstance().save(postDto);
+        Post savePost = PostRepository.getInstance().save(postDto.toEntity());
 
         // Simulate GET request with query parameters
         HttpServletRequest request = new CustomHttpServletRequest();
@@ -131,7 +131,7 @@ public class PostControllerTest {
         body.put("title", new String[]{"title1"});
         body.put("contents", new String[]{"contents1"});
         PostRequestDto postDto = new PostRequestDto(body);
-        PostRepository.getInstance().save(postDto);
+        PostRepository.getInstance().save(postDto.toEntity());
 
         // Simulate GET request with query parameters
         HttpServletRequest request = new CustomHttpServletRequest();
@@ -191,7 +191,7 @@ public class PostControllerTest {
         PostRequestDto postDto = new PostRequestDto(body);
         postDto.setWriter("User One");
         postDto.setMemberId(memberId);
-        Post savePost = PostRepository.getInstance().save(postDto);
+        Post savePost = PostRepository.getInstance().save(postDto.toEntity());
 
         // Simulate PUT request with query parameters
         HttpServletRequest request = new CustomHttpServletRequest();
@@ -225,7 +225,7 @@ public class PostControllerTest {
         PostRequestDto postDto = new PostRequestDto(body);
         postDto.setWriter("User One");
         postDto.setMemberId(memberId);
-        Post savePost = PostRepository.getInstance().save(postDto);
+        Post savePost = PostRepository.getInstance().save(postDto.toEntity());
 
         // Simulate DELETE request with query parameters
         HttpServletRequest request = new CustomHttpServletRequest();
@@ -276,7 +276,7 @@ public class PostControllerTest {
         PostRequestDto postDto = new PostRequestDto(body);
         postDto.setWriter("User One");
         postDto.setMemberId(memberId);
-        Post savePost = PostRepository.getInstance().save(postDto);
+        Post savePost = PostRepository.getInstance().save(postDto.toEntity());
 
         // Simulate PUT request with unauthorized user
         HttpServletRequest request = new CustomHttpServletRequest();
@@ -327,7 +327,7 @@ public class PostControllerTest {
         PostRequestDto postDto = new PostRequestDto(body);
         postDto.setWriter("User One");
         postDto.setMemberId(memberId);
-        Post savePost = PostRepository.getInstance().save(postDto);
+        Post savePost = PostRepository.getInstance().save(postDto.toEntity());
 
         // Simulate DELETE request with unauthorized user
         HttpServletRequest request = new CustomHttpServletRequest();

--- a/src/test/java/codesquad/javacafe/post/repository/PostRepositoryTest.java
+++ b/src/test/java/codesquad/javacafe/post/repository/PostRepositoryTest.java
@@ -90,7 +90,7 @@ public class PostRepositoryTest {
     public void testSave() throws SQLException {
         PostRequestDto postDto = createPostDto("User One", "title", "contents");
         postDto.setMemberId(memberId);
-        postRepository.save(postDto);
+        postRepository.save(postDto.toEntity());
 
         List<Post> posts = postRepository.findAll();
         assertNotNull(posts);
@@ -107,8 +107,8 @@ public class PostRepositoryTest {
         postDto1.setMemberId(memberId);
         postDto2.setMemberId(memberId);
 
-        postRepository.save(postDto1);
-        postRepository.save(postDto2);
+        postRepository.save(postDto1.toEntity());
+        postRepository.save(postDto2.toEntity());
 
         List<Post> posts = postRepository.findAll();
         assertNotNull(posts);
@@ -125,7 +125,7 @@ public class PostRepositoryTest {
     public void testFindById() throws SQLException {
         PostRequestDto postDto = createPostDto("User One", "title", "contents");
         postDto.setMemberId(memberId);
-        postRepository.save(postDto);
+        postRepository.save(postDto.toEntity());
 
         List<Post> posts = postRepository.findAll();
         assertNotNull(posts);
@@ -142,12 +142,12 @@ public class PostRepositoryTest {
     public void testUpdate() throws SQLException {
         PostRequestDto postDto = createPostDto("User One", "title", "contents");
         postDto.setMemberId(memberId);
-        Post savedPost = postRepository.save(postDto);
+        Post savedPost = postRepository.save(postDto.toEntity());
 
         // Update the post
         PostRequestDto updatePost = new PostRequestDto(savedPost.getId(), "updatedTitle", "updatedContents", memberId);
 
-        int rowsAffected = postRepository.update(updatePost);
+        int rowsAffected = postRepository.update(updatePost.toEntity());
 
         assertEquals(1, rowsAffected);
 
@@ -161,7 +161,7 @@ public class PostRepositoryTest {
     public void testDelete() throws SQLException {
         PostRequestDto postDto = createPostDto("User One", "title", "contents");
         postDto.setMemberId(memberId);
-        Post savedPost = postRepository.save(postDto);
+        Post savedPost = postRepository.save(postDto.toEntity());
 
         // Delete the post
         int rowsAffected = postRepository.delete(savedPost.getId());

--- a/src/test/java/codesquad/javacafe/util/CustomHttpServletResponse.java
+++ b/src/test/java/codesquad/javacafe/util/CustomHttpServletResponse.java
@@ -4,6 +4,7 @@ import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collection;
@@ -14,6 +15,8 @@ public class CustomHttpServletResponse implements HttpServletResponse {
     private String redirectedUrl;
     private String forwardedUrl;
     private int statusCode;
+    private final CharArrayWriter charArrayWriter = new CharArrayWriter();
+
 
     @Override
     public void addCookie(Cookie cookie) {
@@ -134,7 +137,11 @@ public class CustomHttpServletResponse implements HttpServletResponse {
 
     @Override
     public PrintWriter getWriter() throws IOException {
-        return null;
+        return new PrintWriter(charArrayWriter);
+    }
+
+    public String getOutput() {
+        return charArrayWriter.toString();
     }
 
     @Override


### PR DESCRIPTION
## 구현 내용
- ajax 댓글 CRUD
- 아직 페이징 처리는 하지 않았습니다.

## 고민 사항
- 댓글도 캐시를 사용하면 좋을까?에 대한 고민이 있었습니다.
  - 어느정도 캐시를 하면 좋겠지만, 게시글 하나 당 10개씩만 캐시해도 꽤 많은 리소스가 필요하다는 생각을 했습니다.
  - 사용자가 정보를 수정했을 때 이 수많은 댓글을 순회하여 처리하면 비효율적일 것 같다는 생각을 했습니다.
  - 그래서 사용하지 않는 편이 좋을 것 같다고 생각했습니다.

- 게시글을 삭제했을 때 join으로 수많은 댓글까지 지우면 병목이 발생한다는 생각을 했습니다.
  - 유튜브와 같은 매우 큰 규모의 서비스에서 수많은 댓글들을 게시글과 함께 지우면 사용자가 느리다는 경험을 한다고 생각했습니다.
  - 댓글의 경우 게시글을 지우면 일반적인 접근으로는 볼 수 없으므로 굳이 사용자가 삭제가 되기까지 기다릴 필요가 없다고 생각했습니다.
  - 별도의 싱글 스레드로 동작하는 스레드 풀 배열을 만들어서 비동기로 처리하여 게시글이 삭제가 되면 빠르게 응답을 반환하도록 했습니다.
  - 댓글 삭제에 실패할 수 있으니 실패한 경우 5번 반복을 하도록 하고 거기서도 실패하면 에러 로그를 남겼습니다.
  - 실제 운영 환경에서는 이런 에러 로그를 영구적으로 잘 기록하여 삭제되지 않은 댓글들이 무한정 쌓이지 않도록 관리가 필요하다고 생각합니다.

## 기타
