### PR TITLE
[최세민] step-7 ajax 댓글 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compileOnly('jakarta.servlet:jakarta.servlet-api:6.0.0')
     implementation('jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api:3.0.0')
     implementation('org.glassfish.web:jakarta.servlet.jsp.jstl:3.0.1')
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.2'
 
     implementation 'mysql:mysql-connector-java:8.0.32'
 

--- a/src/main/java/codesqaud/app/config/ServletContextInitializer.java
+++ b/src/main/java/codesqaud/app/config/ServletContextInitializer.java
@@ -123,7 +123,7 @@ public class ServletContextInitializer implements ServletContextListener {
         ArticleService articleService = new ArticleService(articleDao, replyDao, dataSource);
         servletContext.setAttribute("articleService", articleService);
 
-        ReplyService replyService = new ReplyService(replyDao);
+        ReplyService replyService = new ReplyService(articleDao, replyDao, dataSource);
         servletContext.setAttribute("replyService", replyService);
     }
 }

--- a/src/main/java/codesqaud/app/dao/reply/ReplyDao.java
+++ b/src/main/java/codesqaud/app/dao/reply/ReplyDao.java
@@ -5,8 +5,10 @@ import codesqaud.app.dto.ReplyDto;
 import codesqaud.app.model.Reply;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReplyDao extends CommonDao<Reply, Long> {
     List<Reply> findByArticleId(Long articleId);
+    Optional<ReplyDto> findByIdAsDto(Long id);
     List<ReplyDto> findByArticleIdAsDto(Long articleId);
 }

--- a/src/main/java/codesqaud/app/db/DataSourceUtils.java
+++ b/src/main/java/codesqaud/app/db/DataSourceUtils.java
@@ -11,6 +11,13 @@ import java.sql.SQLException;
 public class DataSourceUtils {
     private static final Logger log = LoggerFactory.getLogger(DataSourceUtils.class);
 
+    /**
+     * Transcation이 진행중인 Connection이 있다면 해당 Connection을 반환합니다.
+     * 그렇지 않다면 DataSource 에서 새로운 Connection을 받아와서 반환합니다.
+     *
+     * @param dataSource
+     * @return
+     */
     public static Connection getConnection(DataSource dataSource) {
         try {
             return doGetConnection(dataSource);
@@ -29,6 +36,12 @@ public class DataSourceUtils {
         return connection;
     }
 
+    /**
+     * 반환하려는 Connection이 Transaction 진행 중이라면 아무런 작업을 하지 않습니다.
+     * Transcation 이 진행중이지 않다면 Connection을 close 합니다.
+     *
+     * @param connection
+     */
     public static void releaseConnection(Connection connection) {
         try {
             doReleaseConnection(connection);

--- a/src/main/java/codesqaud/app/db/TransactionManager.java
+++ b/src/main/java/codesqaud/app/db/TransactionManager.java
@@ -52,7 +52,7 @@ public class TransactionManager {
 
     public static void commit() throws SQLException {
         Connection connection = connectionHolder.get();
-        if(connection == null) {
+        if (connection == null) {
             throw new TransactionException("진행중인 트랜잭션이 없습니다.");
         }
 
@@ -61,7 +61,7 @@ public class TransactionManager {
 
     public static void rollback() throws SQLException {
         Connection connection = connectionHolder.get();
-        if(connection == null) {
+        if (connection == null) {
             throw new TransactionException("진행중인 트랜잭션이 없습니다.");
         }
 

--- a/src/main/java/codesqaud/app/dto/ReplyDto.java
+++ b/src/main/java/codesqaud/app/dto/ReplyDto.java
@@ -1,5 +1,9 @@
 package codesqaud.app.dto;
 
+import codesqaud.app.model.Reply;
+import codesqaud.app.model.User;
+import codesqaud.app.util.TimeUtils;
+
 public class ReplyDto {
     private final Long id;
     private final String contents;
@@ -14,6 +18,16 @@ public class ReplyDto {
         this.activate = activate;
         this.createdAt = createdAt;
         this.author = author;
+    }
+
+    public static ReplyDto from(Reply reply, User user) {
+        return ReplyDto.builder()
+                .id(reply.getId())
+                .contents(reply.getContents())
+                .activate(reply.getActivate())
+                .createdAt(TimeUtils.toStringForUser(reply.getCreatedAt()))
+                .author(UserDto.from(user))
+                .build();
     }
 
     public Long getId() {

--- a/src/main/java/codesqaud/app/dto/UserDto.java
+++ b/src/main/java/codesqaud/app/dto/UserDto.java
@@ -1,5 +1,7 @@
 package codesqaud.app.dto;
 
+import codesqaud.app.model.User;
+
 public class UserDto {
     private final Long id;
     private final String userId;
@@ -11,6 +13,15 @@ public class UserDto {
         this.userId = userId;
         this.name = name;
         this.email = email;
+    }
+
+    public static UserDto from(User user) {
+        return UserDto.builder()
+                .id(user.getId())
+                .userId(user.getUserId())
+                .name(user.getName())
+                .email(user.getEmail())
+                .build();
     }
 
     public Long getId() {
@@ -27,5 +38,44 @@ public class UserDto {
 
     public String getEmail() {
         return email;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private Long id;
+        private String userId;
+        private String name;
+        private String email;
+
+        private Builder() {
+        }
+
+
+        public Builder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder userId(String userId) {
+            this.userId = userId;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder email(String email) {
+            this.email = email;
+            return this;
+        }
+
+        public UserDto build() {
+            return new UserDto(id, userId, name, email);
+        }
     }
 }

--- a/src/main/java/codesqaud/app/filter/HttpMethodOverrideFilter.java
+++ b/src/main/java/codesqaud/app/filter/HttpMethodOverrideFilter.java
@@ -20,7 +20,7 @@ public class HttpMethodOverrideFilter extends HttpFilter {
             req = new HttpServletRequestWrapper(req) {
                 @Override
                 public String getMethod() {
-                    return overridingMethod;
+                    return overridingMethod.toUpperCase();
                 }
             };
         }

--- a/src/main/java/codesqaud/app/model/Reply.java
+++ b/src/main/java/codesqaud/app/model/Reply.java
@@ -44,6 +44,11 @@ public class Reply extends BaseTimeModel {
         return activate;
     }
 
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/src/main/java/codesqaud/app/service/ReplyService.java
+++ b/src/main/java/codesqaud/app/service/ReplyService.java
@@ -86,7 +86,7 @@ public class ReplyService {
             return;
         }
 
-
+        replyDao.delete(reply);
         resp.setStatus(SC_OK);
         String message = "sucess";
         resp.getWriter().write(objectMapper.writeValueAsString(message));

--- a/src/main/java/codesqaud/app/service/ReplyService.java
+++ b/src/main/java/codesqaud/app/service/ReplyService.java
@@ -2,16 +2,19 @@ package codesqaud.app.service;
 
 import codesqaud.app.AuthenticationManager;
 import codesqaud.app.dao.reply.ReplyDao;
+import codesqaud.app.dto.ReplyDto;
 import codesqaud.app.exception.HttpException;
 import codesqaud.app.model.Reply;
 import codesqaud.app.model.User;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import java.io.InputStream;
 
-import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
-import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.*;
 
 public class ReplyService {
     private final ReplyDao replyDao;
@@ -24,13 +27,24 @@ public class ReplyService {
        POST Handlers
      */
     public void handleReplyCreation(HttpServletRequest req, HttpServletResponse resp, Long articleId) throws IOException {
-        String contents = req.getParameter("contents");
+        ObjectMapper objectMapper = new ObjectMapper();
+        InputStream inputStream = req.getInputStream();
+        JsonNode jsonNode = objectMapper.readTree(inputStream);
+
+        String contents = jsonNode.get("contents").asText();
 
         User loginUser = AuthenticationManager.getLoginUserOrElseThrow(req);
         Reply reply = new Reply(contents, articleId, loginUser.getId());
         replyDao.save(reply);
 
-        resp.sendRedirect("/qna/" + articleId);
+        ReplyDto replyDto = replyDao.findByIdAsDto(reply.getId()).orElseThrow(() -> new HttpException(SC_INTERNAL_SERVER_ERROR));
+
+        resp.setContentType("application/json");
+        resp.setCharacterEncoding("UTF-8");
+        resp.setStatus(HttpServletResponse.SC_CREATED);
+
+        String jsonResponse = objectMapper.writeValueAsString(replyDto);
+        resp.getWriter().write(jsonResponse);
     }
 
     /*

--- a/src/main/java/codesqaud/app/util/TimeUtils.java
+++ b/src/main/java/codesqaud/app/util/TimeUtils.java
@@ -14,9 +14,13 @@ public class TimeUtils {
         return OffsetDateTime.ofInstant(timestamp.toInstant(), ZoneId.of("Asia/Seoul"));
     }
 
+    public static String toStringForUser(OffsetDateTime offsetDateTime) {
+        return offsetDateTime.format(FORMAT_FOR_USER);
+    }
+
     public static String toStringForUser(Timestamp timestamp) {
         OffsetDateTime offsetDateTime = toOffsetDateTime(timestamp);
-        return offsetDateTime.toLocalDateTime().format(FORMAT_FOR_USER);
+        return toStringForUser(offsetDateTime);
     }
 
     public static String toStringForQuery(OffsetDateTime offsetDateTime) {

--- a/src/main/webapp/WEB-INF/qna/show.jsp
+++ b/src/main/webapp/WEB-INF/qna/show.jsp
@@ -56,9 +56,11 @@
                 <div class="qna-comment">
                     <div class="qna-comment-slipp">
                         <p class="qna-comment-count"><strong>0</strong>개의 의견</p>
-                        <form class="submit-write answer-write" name="answer" method="POST" action="/qna/${article.id}/replies">
+                        <form class="submit-write answer-write" name="answer" method="POST"
+                              action="/qna/${article.id}/replies">
                             <div class="form-group" style="padding:14px;">
-                                <textarea name="contents" id="contents" class="form-control" placeholder="답변을 작성해보세요."></textarea>
+                                <textarea name="contents" id="contents" class="form-control"
+                                          placeholder="답변을 작성해보세요."></textarea>
                             </div>
                             <button class="btn btn-success pull-right" type="submit">답변하기</button>
                             <div class="clearfix"></div>
@@ -165,8 +167,7 @@
                     <a class="link-modify-article" href="/api/qna/updateAnswer/${article.id}">수정</a>
                 </li>
                 <li>
-                    <form class="delete-answer-form" action="/api/questions/${article.id}/answers/{4}" method="POST">
-                        <input type="hidden" name="_method" value="DELETE">
+                    <form class="delete-answer-form" action="/api/questions/${article.id}/answers/{4}">
                         <button type="submit" class="delete-answer-button">삭제</button>
                     </form>
                 </li>
@@ -184,21 +185,21 @@
         var url = $(".answer-write").attr("action");
 
         var contents = $("#contents").val();
-        var data = JSON.stringify({ contents: contents });
+        var data = JSON.stringify({contents: contents});
 
         console.log(data)
         $.ajax({
-            type : 'POST',
-            url : url,
-            data : data,
+            type: 'POST',
+            url: url,
+            data: data,
             contentType: 'application/json; charset=utf-8',
-            dataType : 'json',
+            dataType: 'json',
             error: function () {
                 alert("error");
             },
-            success : function (data, status) {
+            success: function (data, status) {
                 var answerTemplate = $("#answerTemplate").html();
-                var template = answerTemplate.format(data.id, data.author.userId, data.createdAt, data.contents, data.id);
+                var template = answerTemplate.format(data.id, data.author.name, data.createdAt, data.contents, data.id);
                 console.log(template)
                 $(".qna-comment-slipp-articles").append(template);
                 $("textarea[name=contents]").val("");
@@ -218,6 +219,25 @@
 
     $(".delete-answer-form button[type='submit']").click(deleteAnswer);
 
+    function deleteAnswer(e) {
+        e.preventDefault();
+
+        var deleteBtn = $(this);
+        var url = $(".delete-answer-form").attr("action");
+
+        $.ajax({
+            type: 'DELETE',
+            url: url,
+            dataType: 'json',
+            error: function (xhr, status) {
+                console.log("error");
+            },
+            success: function (data, status) {
+                console.log('data:' + data);
+                deleteBtn.closest("article").remove();
+            }
+        });
+    }
 </script>
 
 </body>

--- a/src/main/webapp/WEB-INF/qna/show.jsp
+++ b/src/main/webapp/WEB-INF/qna/show.jsp
@@ -53,10 +53,16 @@
                         </div>
                     </c:if>
                 </article>
-
                 <div class="qna-comment">
                     <div class="qna-comment-slipp">
                         <p class="qna-comment-count"><strong>0</strong>개의 의견</p>
+                        <form class="submit-write answer-write" name="answer" method="POST" action="/qna/${article.id}/replies">
+                            <div class="form-group" style="padding:14px;">
+                                <textarea name="contents" id="contents" class="form-control" placeholder="답변을 작성해보세요."></textarea>
+                            </div>
+                            <button class="btn btn-success pull-right" type="submit">답변하기</button>
+                            <div class="clearfix"></div>
+                        </form>
                         <div class="qna-comment-slipp-articles">
                             <c:forEach var="reply" items="${replies}" varStatus="status">
                                 <article class="article" id="answer-1405">
@@ -128,14 +134,6 @@
                             <%--                                    </ul>--%>
                             <%--                                </div>--%>
                             <%--                            </article>--%>
-                            <form class="submit-write" method="POST" action="/qna/${article.id}/replies">
-                                <div class="form-group" style="padding:14px;">
-                                    <textarea name="contents" class="form-control"
-                                              placeholder="Update your status"></textarea>
-                                </div>
-                                <button class="btn btn-success pull-right" type="submit">답변하기</button>
-                                <div class="clearfix"/>
-                            </form>
                         </div>
                     </div>
                 </div>
@@ -144,27 +142,30 @@
     </div>
 </div>
 
+<%@include file="/WEB-INF/share/footer.jsp" %>
+
+
 <script type="text/template" id="answerTemplate">
-    <article class="article">
+    <article id="reply-{0}" class="article">
         <div class="article-header">
             <div class="article-header-thumb">
                 <img src="https://graph.facebook.com/v2.3/1324855987/picture" class="article-author-thumb" alt="">
             </div>
             <div class="article-header-text">
-                <a href="#" class="article-author-name">{0}</a>
-                <div class="article-header-time">{1}</div>
+                <a href="#" class="article-author-name">{1}</a>
+                <div class="article-header-time">{2}</div>
             </div>
         </div>
         <div class="article-doc comment-doc">
-            {2}
+            {3}
         </div>
         <div class="article-util">
             <ul class="article-util-list">
                 <li>
-                    <a class="link-modify-article" href="/api/qna/updateAnswer/{3}">수정</a>
+                    <a class="link-modify-article" href="/api/qna/updateAnswer/${article.id}">수정</a>
                 </li>
                 <li>
-                    <form class="delete-answer-form" action="/api/questions/{3}/answers/{4}" method="POST">
+                    <form class="delete-answer-form" action="/api/questions/${article.id}/answers/{4}" method="POST">
                         <input type="hidden" name="_method" value="DELETE">
                         <button type="submit" class="delete-answer-button">삭제</button>
                     </form>
@@ -174,6 +175,50 @@
     </article>
 </script>
 
-<%@include file="/WEB-INF/share/footer.jsp" %>
+<script>
+    $(".submit-write button[type=submit]").click(addAnswer);
+
+    function addAnswer(e) {
+        e.preventDefault();
+
+        var url = $(".answer-write").attr("action");
+
+        var contents = $("#contents").val();
+        var data = JSON.stringify({ contents: contents });
+
+        console.log(data)
+        $.ajax({
+            type : 'POST',
+            url : url,
+            data : data,
+            contentType: 'application/json; charset=utf-8',
+            dataType : 'json',
+            error: function () {
+                alert("error");
+            },
+            success : function (data, status) {
+                var answerTemplate = $("#answerTemplate").html();
+                var template = answerTemplate.format(data.id, data.author.userId, data.createdAt, data.contents, data.id);
+                console.log(template)
+                $(".qna-comment-slipp-articles").append(template);
+                $("textarea[name=contents]").val("");
+
+                var tagId = "reply-" + data.id;
+                window.location.hash = tagId;
+
+                $("#" + tagId).css("background-color", "yellow");
+                setTimeout(function () {
+                    $("#" + tagId).css("background-color", "");
+                }, 2000); // 2초 후 원래 배경색으로 돌아옴
+                // 해당 댓글로 이동
+            }
+        });
+
+    }
+
+    $(".delete-answer-form button[type='submit']").click(deleteAnswer);
+
+</script>
+
 </body>
 </html>

--- a/src/test/java/codesqaud/app/servlet/ReplyUseCaseTest.java
+++ b/src/test/java/codesqaud/app/servlet/ReplyUseCaseTest.java
@@ -3,7 +3,6 @@ package codesqaud.app.servlet;
 import codesqaud.TestDataSource;
 import codesqaud.app.dao.article.ArticleDao;
 import codesqaud.app.dao.reply.ReplyDao;
-import codesqaud.app.exception.HttpException;
 import codesqaud.app.model.Article;
 import codesqaud.app.model.Reply;
 import codesqaud.app.model.User;
@@ -11,6 +10,7 @@ import codesqaud.mock.MockHttpServletRequest;
 import codesqaud.mock.MockHttpServletResponse;
 import codesqaud.mock.MockServletConfig;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.*;
 
@@ -20,7 +20,6 @@ import java.sql.SQLException;
 import static codesqaud.app.AuthenticationManager.getLoginUserOrElseThrow;
 import static codesqaud.util.LoginUtils.signupAndLogin;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 public class ReplyUseCaseTest {
     private QnaServlet qnaServlet;
@@ -49,25 +48,24 @@ public class ReplyUseCaseTest {
     }
 
     @Nested
-    @DisplayName("답글을 작성할 때 때")
+    @DisplayName("답글을 작성할 때")
     class CreateReply {
         @Test
         @DisplayName("답글 내용을 작성하면 댓글을 생성할 수 있다.")
         void given_articleAndReply_when_createReply_then_saveReply() throws ServletException, IOException {
             //given
-            String contents = "Content";
-
+            String body = "{ \"contents\": \"hello\" }";
+            request.setInputStream(body);
             signUpAndLoginAndSaveArticle();
             Article article = articleDao.findAll().get(0);
             request.setRequestURI("/qna/" + article.getId() + "/replies");
-            request.setParameter("contents", contents);
 
             //when
             qnaServlet.doPost(request, response);
 
             //then
             Reply reply = replyDao.findAll().get(0);
-            Assertions.assertThat(reply.getContents()).isEqualTo(contents);
+            Assertions.assertThat(reply.getContents()).isEqualTo("hello");
         }
     }
 
@@ -98,7 +96,7 @@ public class ReplyUseCaseTest {
         }
 
         @Test
-        @DisplayName("삭제할 답변글이 본인의 답변글이면 삭제에 성공한다.")
+        @DisplayName("삭제할 답변글이 본인의 답변이 아니면 삭제가 실패한다.")
         void given_othersReply_when_deleteReply_then_throwException() throws ServletException, IOException {
             //given
             signUpAndLoginAndSaveArticle();
@@ -112,9 +110,12 @@ public class ReplyUseCaseTest {
             request.setMethod("DELETE");
             request.setRequestURI("/qna/"+ article.getId() + "/replies/" + reply.getId());
 
-            //when, then
-            assertThatThrownBy(() -> qnaServlet.doDelete(request, response))
-                    .isInstanceOf(HttpException.class);
+            //when
+            qnaServlet.doDelete(request, response);
+
+            //then
+            assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_FORBIDDEN);
+            assertThat(replyDao.findAll().size()).isEqualTo(1);
         }
     }
 

--- a/src/test/java/codesqaud/mock/MockHttpServletRequest.java
+++ b/src/test/java/codesqaud/mock/MockHttpServletRequest.java
@@ -16,6 +16,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
     private Map<String, Object> attributes = new HashMap<>();
     private MockHttpSession session;
     private MockRequestDispatcher dispatcher;
+    private MockServletInputStream inputStream;
 
     public void setMethod(String method) {
         this.method = method;
@@ -32,6 +33,12 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
     public void setParameter(String name, String value) {
         parameters.put(name, value);
+    }
+
+    public void setInputStream(String body) {
+        MockServletInputStream mockServletInputStream = new MockServletInputStream();
+        mockServletInputStream.setInputStream(body);
+        this.inputStream = mockServletInputStream;
     }
 
     @Override
@@ -63,6 +70,11 @@ public class MockHttpServletRequest implements HttpServletRequest {
     @Override
     public String getRequestURI() {
         return uri;
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        return inputStream;
     }
 
 
@@ -243,11 +255,6 @@ public class MockHttpServletRequest implements HttpServletRequest {
     @Override
     public String getContentType() {
         return "";
-    }
-
-    @Override
-    public ServletInputStream getInputStream() throws IOException {
-        return null;
     }
 
     @Override

--- a/src/test/java/codesqaud/mock/MockHttpServletResponse.java
+++ b/src/test/java/codesqaud/mock/MockHttpServletResponse.java
@@ -6,20 +6,33 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 
 public class MockHttpServletResponse implements HttpServletResponse {
+    private int status;
     private String redirectedUrl;
+    private StringWriter stringWriter = new StringWriter();
+    private PrintWriter writer = new PrintWriter(stringWriter);
+
+    public String getRedirectedUrl() {
+        return redirectedUrl;
+    }
+
+    public String getWrittenContent() {
+        return stringWriter.toString();
+    }
 
     @Override
     public void sendRedirect(String location) throws IOException {
         redirectedUrl = location;
     }
 
-    public String getRedirectedUrl() {
-        return redirectedUrl;
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        return writer;
     }
 
     @Override
@@ -84,12 +97,12 @@ public class MockHttpServletResponse implements HttpServletResponse {
 
     @Override
     public void setStatus(int sc) {
-
+        this.status = sc;
     }
 
     @Override
     public int getStatus() {
-        return 0;
+        return status;
     }
 
     @Override
@@ -119,11 +132,6 @@ public class MockHttpServletResponse implements HttpServletResponse {
 
     @Override
     public ServletOutputStream getOutputStream() throws IOException {
-        return null;
-    }
-
-    @Override
-    public PrintWriter getWriter() throws IOException {
         return null;
     }
 

--- a/src/test/java/codesqaud/mock/MockServletContext.java
+++ b/src/test/java/codesqaud/mock/MockServletContext.java
@@ -37,7 +37,7 @@ public class MockServletContext implements ServletContext {
         ArticleService articleService = new ArticleService(articleDao, replyDao, dataSource);
         attributes.put("articleService", articleService);
 
-        ReplyService replyService = new ReplyService(replyDao);
+        ReplyService replyService = new ReplyService(articleDao, replyDao, dataSource);
         attributes.put("replyService", replyService);
     }
 

--- a/src/test/java/codesqaud/mock/MockServletInputStream.java
+++ b/src/test/java/codesqaud/mock/MockServletInputStream.java
@@ -1,0 +1,40 @@
+package codesqaud.mock;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class MockServletInputStream extends ServletInputStream {
+    private ByteArrayInputStream byteArrayInputStream;
+
+    public void setInputStream(String input) {
+        byte[] bytes = input.getBytes(StandardCharsets.UTF_8);
+        this.byteArrayInputStream = new ByteArrayInputStream(bytes);
+    }
+
+    @Override
+    public boolean isFinished() {
+        return byteArrayInputStream == null || byteArrayInputStream.available() == 0;
+    }
+
+    @Override
+    public boolean isReady() {
+        return true;
+    }
+
+    @Override
+    public void setReadListener(ReadListener readListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (byteArrayInputStream == null) {
+            return -1;
+        }
+        return byteArrayInputStream.read();
+    }
+}


### PR DESCRIPTION
## 구현 내용
-ajax 댓글 작성, 삭제 구현
  - 댓글 삭제할 때에도 게시글 상태 확인 및 트랜잭션 적용

## 고민 사항
- 게시글 상세보기에 접근했을 때 댓글은 서버에서 렌더링하고 있습니다. 새로 댓글을 작성할땐 api로 클라이언트측에서 렌더링하고 있습니다.
 일관성이 유지되지 않아 어떻게 일관성을 유지할 지 고민입니다.

## 기타
- 트랜잭션 테스트 코드에 테스트 기능이 오류가 있는 것을 발견했습니다. 다음 PR까지 수정할 예정입니다.