### PR TITLE
[이호석] step-8 페이징 구현하기

### DIFF
--- a/.github/workflows/ciAndDeploy.yml
+++ b/.github/workflows/ciAndDeploy.yml
@@ -1,8 +1,9 @@
 name: Java CI with Gradle
 on:
   push:
+    branches: [ "HiiWee" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "HiiWee" ]
 jobs:
   build:
 

--- a/.github/workflows/ciAndDeploy.yml
+++ b/.github/workflows/ciAndDeploy.yml
@@ -1,0 +1,49 @@
+name: Java CI with Gradle
+on:
+  push:
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle And Test
+        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda # v3.4.2
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew clean test
+
+      - name: Get branch name
+        id: branch-name
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "BRANCH_NAME=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "BRANCH_NAME=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Add SSH key to known hosts
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
+
+      - name: run deploy script
+        env:
+          SSH_SERVER_INFO: ${{ secrets.SSH_SERVER_INFO }}
+          PEM_KEY: ${{ secrets.PEM_KEY }}
+          SCRIPT_PATH: ${{ secrets.SCRIPT_PATH }}
+        run: |
+          echo "$PEM_KEY" > private_key
+          chmod 600 private_key
+          ssh -i private_key $SSH_SERVER_INFO "bash $SCRIPT_PATH ${{ steps.branch-name.outputs.BRANCH_NAME }}"

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+datasource-prod.properties

--- a/src/main/java/com/wootecam/jspcafe/config/DataSourceManager.java
+++ b/src/main/java/com/wootecam/jspcafe/config/DataSourceManager.java
@@ -2,10 +2,8 @@ package com.wootecam.jspcafe.config;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Properties;
 import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,18 +14,16 @@ public class DataSourceManager {
 
     private final DataSource dataSource;
 
-    public DataSourceManager() {
-        Properties props = new Properties();
-        loadProperties(props);
-        String driverClassName = props.getProperty("datasource.driverClassName");
+    public DataSourceManager(final DataSourceProperty dataSourceProperty) {
+        String driverClassName = dataSourceProperty.getDriverClassName();
         try {
             Class.forName(driverClassName);
         } catch (ClassNotFoundException e) {
             log.error("드라이버 클래스를 로딩할 수 없습니다.");
         }
-        String url = props.getProperty("datasource.url");
-        String user = props.getProperty("datasource.user");
-        String password = props.getProperty("datasource.password");
+        String url = dataSourceProperty.getUrl();
+        String user = dataSourceProperty.getUser();
+        String password = dataSourceProperty.getPassword();
 
         HikariConfig hikariConfig = new HikariConfig();
         hikariConfig.setDriverClassName(driverClassName);
@@ -36,14 +32,6 @@ public class DataSourceManager {
         hikariConfig.setPassword(password);
 
         dataSource = new HikariDataSource(hikariConfig);
-    }
-
-    private void loadProperties(final Properties props) {
-        try {
-            props.load(getClass().getClassLoader().getResourceAsStream("config/datasource.properties"));
-        } catch (IOException e) {
-            log.error(e.getMessage(), e);
-        }
     }
 
     public Connection getConnection() throws SQLException {

--- a/src/main/java/com/wootecam/jspcafe/config/DataSourceProperty.java
+++ b/src/main/java/com/wootecam/jspcafe/config/DataSourceProperty.java
@@ -20,10 +20,9 @@ public class DataSourceProperty {
             String profile = System.getenv("PROFILE");
             if (profile == null) {
                 properties.load(getClass().getClassLoader().getResourceAsStream("config/datasource.properties"));
-                properties.load(
-                        getClass().getClassLoader().getResourceAsStream("config/" + properties.getProperty("profile")));
-                return;
+                profile = properties.getProperty("profile");
             }
+            log.info("PROFILE='{}' is Loading", profile);
             properties.load(getClass().getClassLoader().getResourceAsStream("config/" + profile));
         } catch (IOException e) {
             log.error(e.getMessage(), e);

--- a/src/main/java/com/wootecam/jspcafe/config/DataSourceProperty.java
+++ b/src/main/java/com/wootecam/jspcafe/config/DataSourceProperty.java
@@ -1,0 +1,52 @@
+package com.wootecam.jspcafe.config;
+
+import java.io.IOException;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataSourceProperty {
+
+    private static final Logger log = LoggerFactory.getLogger(DataSourceProperty.class);
+
+    private final Properties properties = new Properties();
+
+    public DataSourceProperty() {
+        loadProperties();
+    }
+
+    private void loadProperties() {
+        try {
+            String profile = System.getenv("PROFILE");
+            if (profile == null) {
+                properties.load(getClass().getClassLoader().getResourceAsStream("config/datasource.properties"));
+                properties.load(
+                        getClass().getClassLoader().getResourceAsStream("config/" + properties.getProperty("profile")));
+                return;
+            }
+            properties.load(getClass().getClassLoader().getResourceAsStream("config/" + profile));
+        } catch (IOException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    private String getProperty(final String key) {
+        return properties.getProperty(key);
+    }
+
+    public String getDriverClassName() {
+        return getProperty("datasource.driverClassName");
+    }
+
+    public String getUrl() {
+        return getProperty("datasource.url");
+    }
+
+    public String getUser() {
+        return getProperty("datasource.user");
+    }
+
+    public String getPassword() {
+        return getProperty("datasource.password");
+    }
+}

--- a/src/main/java/com/wootecam/jspcafe/config/DataSourceProperty.java
+++ b/src/main/java/com/wootecam/jspcafe/config/DataSourceProperty.java
@@ -11,13 +11,10 @@ public class DataSourceProperty {
 
     private final Properties properties = new Properties();
 
-    public DataSourceProperty() {
-        loadProperties();
-    }
+    public DataSourceProperty(final String profileKey) {
+        String profile = System.getenv(profileKey);
 
-    private void loadProperties() {
         try {
-            String profile = System.getenv("PROFILE");
             if (profile == null) {
                 properties.load(getClass().getClassLoader().getResourceAsStream("config/datasource.properties"));
                 profile = properties.getProperty("profile");

--- a/src/main/java/com/wootecam/jspcafe/config/JdbcTemplate.java
+++ b/src/main/java/com/wootecam/jspcafe/config/JdbcTemplate.java
@@ -70,6 +70,17 @@ public class JdbcTemplate {
         }
     }
 
+    public <T> T selectOne(final String query, final ResultSetMapper<T> mapper) {
+        try (Connection conn = dataSourceManager.getConnection();
+             PreparedStatement ps = conn.prepareStatement(query)) {
+
+            return getValue(mapper, ps);
+        } catch (SQLException e) {
+            log.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
     private <T> T getValue(final ResultSetMapper<T> mapper, final PreparedStatement ps) throws SQLException {
         T value = null;
 

--- a/src/main/java/com/wootecam/jspcafe/domain/QuestionRepository.java
+++ b/src/main/java/com/wootecam/jspcafe/domain/QuestionRepository.java
@@ -7,7 +7,9 @@ public interface QuestionRepository {
 
     void save(final Question question);
 
-    List<Question> findAllOrderByCreatedTimeDesc();
+    int countAll();
+
+    List<Question> findAllOrderByCreatedTimeDesc(final int page, final int size);
 
     Optional<Question> findById(final Long id);
 

--- a/src/main/java/com/wootecam/jspcafe/domain/ReplyRepository.java
+++ b/src/main/java/com/wootecam/jspcafe/domain/ReplyRepository.java
@@ -9,11 +9,15 @@ public interface ReplyRepository {
 
     Optional<Reply> findById(Long id);
 
-    List<Reply> findAllByQuestionPrimaryId(Long questionId);
+    List<Reply> findAllByQuestionPrimaryIdLimit(Long questionPrimaryId, int count);
 
     void delete(Long id);
 
     boolean existsReplyByIdAndOtherUserPrimaryId(final Long id, Long userPrimaryId);
 
     void deleteAllByQuestionPrimaryId(Long questionPrimaryId);
+
+    int countAll(final Long questionPrimaryId);
+
+    List<Reply> findAllByQuestionPrimaryIdAndStartWith(Long questionPrimaryId, Long lastReplyId, int count);
 }

--- a/src/main/java/com/wootecam/jspcafe/listener/ApplicationContextListener.java
+++ b/src/main/java/com/wootecam/jspcafe/listener/ApplicationContextListener.java
@@ -3,6 +3,7 @@ package com.wootecam.jspcafe.listener;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.wootecam.jspcafe.config.DataSourceManager;
+import com.wootecam.jspcafe.config.DataSourceProperty;
 import com.wootecam.jspcafe.config.JdbcTemplate;
 import com.wootecam.jspcafe.domain.QuestionRepository;
 import com.wootecam.jspcafe.domain.ReplyRepository;
@@ -37,7 +38,8 @@ public class ApplicationContextListener implements ServletContextListener {
     @Override
     public void contextInitialized(final ServletContextEvent sce) {
         ServletContext servletContext = sce.getServletContext();
-        DataSourceManager dataSourceManager = new DataSourceManager();
+        DataSourceProperty dataSourceProperty = new DataSourceProperty();
+        DataSourceManager dataSourceManager = new DataSourceManager(dataSourceProperty);
         servletContext.setAttribute("dataSourceManager", dataSourceManager);
 
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/wootecam/jspcafe/listener/ApplicationContextListener.java
+++ b/src/main/java/com/wootecam/jspcafe/listener/ApplicationContextListener.java
@@ -38,7 +38,7 @@ public class ApplicationContextListener implements ServletContextListener {
     @Override
     public void contextInitialized(final ServletContextEvent sce) {
         ServletContext servletContext = sce.getServletContext();
-        DataSourceProperty dataSourceProperty = new DataSourceProperty();
+        DataSourceProperty dataSourceProperty = new DataSourceProperty("PROFILE");
         DataSourceManager dataSourceManager = new DataSourceManager(dataSourceProperty);
         servletContext.setAttribute("dataSourceManager", dataSourceManager);
 

--- a/src/main/java/com/wootecam/jspcafe/service/QuestionService.java
+++ b/src/main/java/com/wootecam/jspcafe/service/QuestionService.java
@@ -31,8 +31,12 @@ public class QuestionService {
         questionRepository.save(question);
     }
 
-    public List<Question> readAll() {
-        return questionRepository.findAllOrderByCreatedTimeDesc();
+    public int countAll() {
+        return questionRepository.countAll();
+    }
+
+    public List<Question> readAll(final int page, final int size) {
+        return questionRepository.findAllOrderByCreatedTimeDesc(page, size);
     }
 
     public Question read(final Long id) {

--- a/src/main/java/com/wootecam/jspcafe/service/ReplyService.java
+++ b/src/main/java/com/wootecam/jspcafe/service/ReplyService.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 public class ReplyService {
 
+    private static final int MINIMUM_REPLY_COUNT = 1;
+
     private final ReplyRepository replyRepository;
 
     public ReplyService(final ReplyRepository replyRepository) {
@@ -27,8 +29,16 @@ public class ReplyService {
                 .orElseThrow(() -> new NotFoundException("댓글을 찾을 수 없습니다."));
     }
 
-    public List<Reply> readAll(final Long questionId) {
-        return replyRepository.findAllByQuestionPrimaryId(questionId);
+    public int countAll(final Long questionPrimaryId) {
+        return replyRepository.countAll(questionPrimaryId);
+    }
+
+    public List<Reply> readAll(final Long questionId, final int readCount) {
+        if (readCount < MINIMUM_REPLY_COUNT) {
+            String message = String.format("댓글 조회 갯수는 %d개 이상이어야 합니다.", MINIMUM_REPLY_COUNT);
+            throw new BadRequestException(message);
+        }
+        return replyRepository.findAllByQuestionPrimaryIdLimit(questionId, readCount);
     }
 
     public void delete(final Long replyId, final Long userPrimaryId) {
@@ -39,5 +49,14 @@ public class ReplyService {
         }
 
         replyRepository.delete(replyId);
+    }
+
+    public List<Reply> readAllStartsWith(final Long questionId, final Long lastReplyId, final int readCount) {
+        if (readCount < MINIMUM_REPLY_COUNT) {
+            String message = String.format("댓글 조회 갯수는 %d개 이상이어야 합니다.", MINIMUM_REPLY_COUNT);
+            throw new BadRequestException(message);
+        }
+
+        return replyRepository.findAllByQuestionPrimaryIdAndStartWith(questionId, lastReplyId, readCount);
     }
 }

--- a/src/main/java/com/wootecam/jspcafe/servlet/AbstractHttpServlet.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/AbstractHttpServlet.java
@@ -21,6 +21,11 @@ public abstract class AbstractHttpServlet extends HttpServlet {
         } catch (CommonException e) {
             log.debug(e.getMessage(), e);
             responseError(req, resp, e);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+            responseError(req, resp,
+                    new CommonException("서버에서 에러가 발생했습니다.", HttpServletResponse.SC_INTERNAL_SERVER_ERROR))
+            ;
         }
     }
 

--- a/src/main/java/com/wootecam/jspcafe/servlet/HomeServlet.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/HomeServlet.java
@@ -2,17 +2,15 @@ package com.wootecam.jspcafe.servlet;
 
 import com.wootecam.jspcafe.domain.Question;
 import com.wootecam.jspcafe.service.QuestionService;
+import com.wootecam.jspcafe.servlet.dto.QuestionsPageResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Objects;
 
 public class HomeServlet extends AbstractHttpServlet {
-
-    private static final Logger log = LoggerFactory.getLogger(HomeServlet.class);
 
     private final QuestionService questionService;
 
@@ -23,12 +21,31 @@ public class HomeServlet extends AbstractHttpServlet {
     @Override
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
             throws ServletException, IOException {
-        List<Question> questions = questionService.readAll();
-        req.setAttribute("questions", questions);
+        int questionCount = questionService.countAll();
+        int page = parsePage(req.getParameter("page"));
+        int size = parseSize(req.getParameter("size"));
 
-        log.debug("forward to home");
+        List<Question> questions;
+        questions = questionService.readAll(page, size);
+
+        QuestionsPageResponse response = QuestionsPageResponse.of(questionCount, page, questions);
+        req.setAttribute("questions", response);
 
         req.getRequestDispatcher("/WEB-INF/views/index.jsp")
                 .forward(req, resp);
+    }
+
+    private int parseSize(final String size) {
+        if (Objects.isNull(size)) {
+            return 15;
+        }
+        return Integer.parseInt(size);
+    }
+
+    private int parsePage(final String page) {
+        if (Objects.isNull(page)) {
+            return 1;
+        }
+        return Integer.parseInt(page);
     }
 }

--- a/src/main/java/com/wootecam/jspcafe/servlet/dto/QuestionResponse.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/dto/QuestionResponse.java
@@ -1,0 +1,45 @@
+package com.wootecam.jspcafe.servlet.dto;
+
+import com.wootecam.jspcafe.domain.Question;
+import java.time.LocalDateTime;
+
+public class QuestionResponse {
+
+    private final Long id;
+    private final String writer;
+    private final String title;
+    private final LocalDateTime createdTime;
+
+    public QuestionResponse(final Long id, final String writer, final String title,
+                            final LocalDateTime createdTime) {
+        this.id = id;
+        this.writer = writer;
+        this.title = title;
+        this.createdTime = createdTime;
+    }
+
+    public static QuestionResponse from(Question question) {
+        return new QuestionResponse(
+                question.getId(),
+                question.getWriter(),
+                question.getTitle(),
+                question.getCreatedTime()
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getWriter() {
+        return writer;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public LocalDateTime getCreatedTime() {
+        return createdTime;
+    }
+}

--- a/src/main/java/com/wootecam/jspcafe/servlet/dto/QuestionsPageResponse.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/dto/QuestionsPageResponse.java
@@ -1,0 +1,41 @@
+package com.wootecam.jspcafe.servlet.dto;
+
+import com.wootecam.jspcafe.domain.Question;
+import java.util.List;
+
+public class QuestionsPageResponse {
+
+    private final int questionCount;
+    private final int currentPage;
+    private final List<QuestionResponse> questionResponses;
+
+    public QuestionsPageResponse(final int questionCount, final int currentPage, final List<QuestionResponse> questionResponses) {
+        this.questionCount = questionCount;
+        this.currentPage = currentPage;
+        this.questionResponses = questionResponses;
+    }
+
+    public static QuestionsPageResponse of(final int questionCount, final int currentPage, final List<Question> questions) {
+        List<QuestionResponse> questionResponses = questions.stream()
+                .map(QuestionResponse::from)
+                .toList();
+
+        return new QuestionsPageResponse(
+                questionCount,
+                currentPage,
+                questionResponses
+        );
+    }
+
+    public int getQuestionCount() {
+        return questionCount;
+    }
+
+    public int getCurrentPage() {
+        return currentPage;
+    }
+
+    public List<QuestionResponse> getQuestionResponses() {
+        return questionResponses;
+    }
+}

--- a/src/main/java/com/wootecam/jspcafe/servlet/dto/QuestionsPageResponse.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/dto/QuestionsPageResponse.java
@@ -9,13 +9,15 @@ public class QuestionsPageResponse {
     private final int currentPage;
     private final List<QuestionResponse> questionResponses;
 
-    public QuestionsPageResponse(final int questionCount, final int currentPage, final List<QuestionResponse> questionResponses) {
+    public QuestionsPageResponse(final int questionCount, final int currentPage,
+                                 final List<QuestionResponse> questionResponses) {
         this.questionCount = questionCount;
         this.currentPage = currentPage;
         this.questionResponses = questionResponses;
     }
 
-    public static QuestionsPageResponse of(final int questionCount, final int currentPage, final List<Question> questions) {
+    public static QuestionsPageResponse of(final int questionCount, final int currentPage,
+                                           final List<Question> questions) {
         List<QuestionResponse> questionResponses = questions.stream()
                 .map(QuestionResponse::from)
                 .toList();

--- a/src/main/java/com/wootecam/jspcafe/servlet/dto/RepliesAppendPageResponse.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/dto/RepliesAppendPageResponse.java
@@ -1,0 +1,36 @@
+package com.wootecam.jspcafe.servlet.dto;
+
+import com.wootecam.jspcafe.domain.Reply;
+import java.util.List;
+
+public class RepliesAppendPageResponse {
+
+    private final Long lastReplyId;
+    private final List<ReplyResponse> replies;
+
+    public RepliesAppendPageResponse(final Long lastReplyId, final List<ReplyResponse> replies) {
+        this.lastReplyId = lastReplyId;
+        this.replies = replies;
+    }
+
+    public static RepliesAppendPageResponse of(final List<Reply> replies) {
+        List<ReplyResponse> responses = replies.stream()
+                .map(ReplyResponse::from)
+                .toList();
+
+        Long lastReplyId = -1L;
+        if (!replies.isEmpty()) {
+            lastReplyId = replies.get(replies.size() - 1).getId();
+        }
+
+        return new RepliesAppendPageResponse(lastReplyId, responses);
+    }
+
+    public Long getLastReplyId() {
+        return lastReplyId;
+    }
+
+    public List<ReplyResponse> getReplies() {
+        return replies;
+    }
+}

--- a/src/main/java/com/wootecam/jspcafe/servlet/dto/RepliesPageResponse.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/dto/RepliesPageResponse.java
@@ -1,0 +1,42 @@
+package com.wootecam.jspcafe.servlet.dto;
+
+import com.wootecam.jspcafe.domain.Reply;
+import java.util.List;
+
+public class RepliesPageResponse {
+
+    private final int replyCount;
+    private final Long lastReplyId;
+    private final List<ReplyResponse> replies;
+
+    public RepliesPageResponse(final int replyCount, final Long lastReplyId, final List<ReplyResponse> replies) {
+        this.replyCount = replyCount;
+        this.lastReplyId = lastReplyId;
+        this.replies = replies;
+    }
+
+    public static RepliesPageResponse of(final int replyCount, final List<Reply> replies) {
+        List<ReplyResponse> responses = replies.stream()
+                .map(ReplyResponse::from)
+                .toList();
+
+        Long lastReplyId = -1L;
+        if (!replies.isEmpty()) {
+            lastReplyId = replies.get(replies.size() - 1).getId();
+        }
+
+        return new RepliesPageResponse(replyCount, lastReplyId, responses);
+    }
+
+    public int getReplyCount() {
+        return replyCount;
+    }
+
+    public Long getLastReplyId() {
+        return lastReplyId;
+    }
+
+    public List<ReplyResponse> getReplies() {
+        return replies;
+    }
+}

--- a/src/main/java/com/wootecam/jspcafe/servlet/dto/ReplyResponse.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/dto/ReplyResponse.java
@@ -1,0 +1,39 @@
+package com.wootecam.jspcafe.servlet.dto;
+
+import com.wootecam.jspcafe.domain.Reply;
+import java.time.LocalDateTime;
+
+public class ReplyResponse {
+
+    private Long id;
+    private final String writer;
+    private final String contents;
+    private final LocalDateTime createdTime;
+
+    public ReplyResponse(final Long id, final String writer, final String contents, final LocalDateTime createdTime) {
+        this.id = id;
+        this.writer = writer;
+        this.contents = contents;
+        this.createdTime = createdTime;
+    }
+
+    public static ReplyResponse from(Reply reply) {
+        return new ReplyResponse(reply.getId(), reply.getWriter(), reply.getContents(), reply.getCreatedTime());
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getWriter() {
+        return writer;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+
+    public LocalDateTime getCreatedTime() {
+        return createdTime;
+    }
+}

--- a/src/main/java/com/wootecam/jspcafe/servlet/question/QuestionDetailServlet.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/question/QuestionDetailServlet.java
@@ -6,6 +6,7 @@ import com.wootecam.jspcafe.domain.User;
 import com.wootecam.jspcafe.service.QuestionService;
 import com.wootecam.jspcafe.service.ReplyService;
 import com.wootecam.jspcafe.servlet.AbstractHttpServlet;
+import com.wootecam.jspcafe.servlet.dto.RepliesPageResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -40,12 +41,15 @@ public class QuestionDetailServlet extends AbstractHttpServlet {
         Long id = parseSuffixPathVariable(req.getPathInfo());
 
         Question question = questionService.read(id);
-        List<Reply> replies = replyService.readAll(question.getId());
+        int replyCount = replyService.countAll(question.getId());
+        List<Reply> replies = replyService.readAll(question.getId(), 5);
+
+        RepliesPageResponse response = RepliesPageResponse.of(replyCount, replies);
 
         log.info(question.toString());
 
         req.setAttribute("question", question);
-        req.setAttribute("replies", replies);
+        req.setAttribute("replyPageResponse", response);
 
         req.getRequestDispatcher("/WEB-INF/views/qna/show.jsp")
                 .forward(req, resp);

--- a/src/main/java/com/wootecam/jspcafe/servlet/reply/ReplyServlet.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/reply/ReplyServlet.java
@@ -4,13 +4,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wootecam.jspcafe.domain.Reply;
 import com.wootecam.jspcafe.domain.User;
 import com.wootecam.jspcafe.exception.CommonException;
+import com.wootecam.jspcafe.exception.NotFoundException;
 import com.wootecam.jspcafe.service.ReplyService;
 import com.wootecam.jspcafe.servlet.AbstractHttpServlet;
+import com.wootecam.jspcafe.servlet.dto.RepliesAppendPageResponse;
 import com.wootecam.jspcafe.servlet.util.HttpBodyParser;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -25,8 +28,30 @@ public class ReplyServlet extends AbstractHttpServlet {
     }
 
     @Override
-    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp)
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp)
             throws ServletException, IOException {
+        User signInUser = (User) req.getSession().getAttribute("signInUser");
+
+        if (Objects.isNull(signInUser)) {
+            throw new CommonException("로그인을 해야 합니다.", HttpServletResponse.SC_UNAUTHORIZED);
+        }
+
+        String lastReplyId = req.getParameter("lastReplyId");
+        String questionId = req.getParameter("questionId");
+
+        if (Objects.isNull(lastReplyId) || Objects.isNull(questionId)) {
+            throw new NotFoundException("질문을 찾을 수 없습니다.");
+        }
+        List<Reply> replies = replyService.readAllStartsWith(Long.parseLong(questionId), Long.parseLong(lastReplyId),
+                5);
+        RepliesAppendPageResponse response = RepliesAppendPageResponse.of(replies);
+
+        resp.getWriter()
+                .write(mapper.writeValueAsString(response));
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
         User signInUser = (User) req.getSession().getAttribute("signInUser");
 
         if (Objects.isNull(signInUser)) {

--- a/src/main/java/com/wootecam/jspcafe/servlet/user/UserServlet.java
+++ b/src/main/java/com/wootecam/jspcafe/servlet/user/UserServlet.java
@@ -38,6 +38,6 @@ public class UserServlet extends AbstractHttpServlet {
                 req.getParameter("email")
         );
 
-        resp.sendRedirect("/users");
+        resp.sendRedirect("/");
     }
 }

--- a/src/main/resources/config/datasource-local.properties
+++ b/src/main/resources/config/datasource-local.properties
@@ -1,0 +1,4 @@
+datasource.driverClassName=com.mysql.cj.jdbc.Driver
+datasource.url=jdbc:mysql://127.0.0.1:3306/jsp_cafe?characterEncoding=UTF-8&useUnicode=true&rewriteBatchedStatements=true
+datasource.user=hoseok
+datasource.password=1234

--- a/src/main/resources/config/datasource-test.properties
+++ b/src/main/resources/config/datasource-test.properties
@@ -1,0 +1,4 @@
+datasource.driverClassName=org.h2.Driver
+datasource.url=jdbc:h2:mem:db
+datasource.user=sa
+datasource.password=

--- a/src/main/resources/config/datasource.properties
+++ b/src/main/resources/config/datasource.properties
@@ -1,4 +1,1 @@
-datasource.driverClassName=com.mysql.cj.jdbc.Driver
-datasource.url=jdbc:mysql://127.0.0.1:3306/jsp_cafe?characterEncoding=UTF-8&useUnicode=true&rewriteBatchedStatements=true
-datasource.user=hoseok
-datasource.password=1234
+profile=datasource-local.properties

--- a/src/main/webapp/WEB-INF/views/index.jsp
+++ b/src/main/webapp/WEB-INF/views/index.jsp
@@ -13,7 +13,7 @@
     <div class="col-md-12 col-sm-12 col-lg-10 col-lg-offset-1">
         <div class="panel panel-default qna-list">
             <ul class="list">
-                <c:forEach var="question" items="${questions}" varStatus="status">
+                <c:forEach var="question" items="${questions.questionResponses}" varStatus="status">
                     <li>
                         <div class="wrap">
                             <div class="main">
@@ -42,13 +42,28 @@
                 <div class="col-md-3"></div>
                 <div class="col-md-6 text-center">
                     <ul class="pagination center-block" style="display:inline-block;">
-                        <li><a href="#">«</a></li>
-                        <li><a href="#">1</a></li>
-                        <li><a href="#">2</a></li>
-                        <li><a href="#">3</a></li>
-                        <li><a href="#">4</a></li>
-                        <li><a href="#">5</a></li>
-                        <li><a href="#">»</a></li>
+
+                        <fmt:parseNumber var="totalPage" integerOnly="true"
+                                         value="${(questions.questionCount + 14) / 15}"/>
+                        <c:set var="currentPage" value="${questions.currentPage}"/>
+
+                        <fmt:parseNumber var="pageGroup" integerOnly="true" value="${(currentPage - 1) / 5}"/>
+                        <c:set var="startPage" value="${pageGroup * 5 + 1}"/>
+                        <c:set var="endPage" value="${Math.min(startPage + 4, totalPage)}"/>
+
+                        <c:if test="${startPage > 1}">
+                            <li><a href="?page=${startPage - 5}">«</a></li>
+                        </c:if>
+
+                        <c:forEach begin="${startPage}" end="${endPage}" var="i">
+                            <li class="${i == currentPage ? 'active' : ''}">
+                                <a href="?page=${i}">${i}</a>
+                            </li>
+                        </c:forEach>
+
+                        <c:if test="${endPage < totalPage}">
+                            <li><a href="?page=${startPage + 5}">»</a></li>
+                        </c:if>
                     </ul>
                 </div>
                 <div class="col-md-3 qna-write">

--- a/src/test/java/com/wootecam/jspcafe/config/DataSourcePropertyTest.java
+++ b/src/test/java/com/wootecam/jspcafe/config/DataSourcePropertyTest.java
@@ -10,7 +10,7 @@ class DataSourcePropertyTest {
     @Test
     void 테스트_데이터_소스를_불러올_수_있다() {
         // when
-        DataSourceProperty dataSourceProperty = new DataSourceProperty();
+        DataSourceProperty dataSourceProperty = new DataSourceProperty("TEST");
 
         // then
         assertAll(

--- a/src/test/java/com/wootecam/jspcafe/config/DataSourcePropertyTest.java
+++ b/src/test/java/com/wootecam/jspcafe/config/DataSourcePropertyTest.java
@@ -1,0 +1,23 @@
+package com.wootecam.jspcafe.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.Test;
+
+class DataSourcePropertyTest {
+
+    @Test
+    void 테스트_데이터_소스를_불러올_수_있다() {
+        // when
+        DataSourceProperty dataSourceProperty = new DataSourceProperty();
+
+        // then
+        assertAll(
+                () -> assertThat(dataSourceProperty.getDriverClassName()).isEqualTo("org.h2.Driver"),
+                () -> assertThat(dataSourceProperty.getUrl()).isEqualTo("jdbc:h2:mem:db"),
+                () -> assertThat(dataSourceProperty.getUser()).isEqualTo("sa"),
+                () -> assertThat(dataSourceProperty.getPassword()).isEqualTo("")
+        );
+    }
+}

--- a/src/test/java/com/wootecam/jspcafe/service/QuestionServiceTest.java
+++ b/src/test/java/com/wootecam/jspcafe/service/QuestionServiceTest.java
@@ -82,6 +82,25 @@ class QuestionServiceTest extends ServiceTest {
     }
 
     @Nested
+    class countAll_메소드는 {
+
+        @Test
+        void 현재_존재하는_모든_질문의_갯수를_반환한다() {
+            // given
+            userRepository.save(new User("userId", "password", "name", "email"));
+            questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
+            questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
+            questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
+
+            // when
+            int questionCount = questionService.countAll();
+
+            // then
+            assertThat(questionCount).isEqualTo(3);
+        }
+    }
+
+    @Nested
     class readAll_메소드는 {
 
         @Test
@@ -93,11 +112,34 @@ class QuestionServiceTest extends ServiceTest {
             questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
 
             // when
-            List<Question> questions = questionService.readAll();
+            List<Question> questions = questionService.readAll(0, 15);
 
             // then
             assertThat(questions).size()
                     .isEqualTo(3);
+        }
+
+        @Nested
+        class 페이징_요청으로_페이지와_사이즈를_전달하면 {
+
+            @Test
+            void 페이지네이션을_한다() {
+                userRepository.save(new User("userId", "password", "name", "email"));
+                questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
+                questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
+                questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
+                questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
+
+                // when
+                List<Question> questions = questionService.readAll(0, 2);
+
+                // then
+                assertAll(
+                        () -> assertThat(questions).hasSize(2),
+                        () -> assertThat(questions.get(0).getId()).isEqualTo(4),
+                        () -> assertThat(questions.get(1).getId()).isEqualTo(3)
+                );
+            }
         }
     }
 

--- a/src/test/java/com/wootecam/jspcafe/service/QuestionServiceTest.java
+++ b/src/test/java/com/wootecam/jspcafe/service/QuestionServiceTest.java
@@ -112,7 +112,7 @@ class QuestionServiceTest extends ServiceTest {
             questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
 
             // when
-            List<Question> questions = questionService.readAll(0, 15);
+            List<Question> questions = questionService.readAll(1, 15);
 
             // then
             assertThat(questions).size()
@@ -131,7 +131,7 @@ class QuestionServiceTest extends ServiceTest {
                 questionRepository.save(new Question("작성자", "제목입니다.", "내용입니다.", LocalDateTime.now(), 1L));
 
                 // when
-                List<Question> questions = questionService.readAll(0, 2);
+                List<Question> questions = questionService.readAll(1, 2);
 
                 // then
                 assertAll(
@@ -341,7 +341,7 @@ class QuestionServiceTest extends ServiceTest {
 
                 // when
                 questionService.delete(1L, 1L);
-                List<Reply> replies = replyRepository.findAllByQuestionPrimaryId(1L);
+                List<Reply> replies = replyRepository.findAllByQuestionPrimaryIdLimit(1L, 5);
 
                 // then
                 assertThat(replies).isEmpty();

--- a/src/test/java/com/wootecam/jspcafe/service/ReplyServiceTest.java
+++ b/src/test/java/com/wootecam/jspcafe/service/ReplyServiceTest.java
@@ -52,6 +52,47 @@ class ReplyServiceTest extends ServiceTest {
     }
 
     @Nested
+    class countAll_메소드는 {
+
+        @Nested
+        class 만약_특정_질문의_댓글이_없다면 {
+
+            @Test
+            void zero를_반환한다() {
+                // given
+                userRepository.save(new User("userId", "password", "name", "mail@mail.com"));
+                questionRepository.save(new Question("userId", "title", "contents", LocalDateTime.now(), 1L));
+
+                // when
+                int count = replyService.countAll(1L);
+
+                // then
+                assertThat(count).isZero();
+            }
+        }
+
+        @Nested
+        class 만약_특정_질문에_댓글이_N개라면 {
+
+            @Test
+            void N개를_반환한다() {
+                // given
+                userRepository.save(new User("userId", "password", "name", "mail@mail.com"));
+                questionRepository.save(new Question("userId", "title", "contents", LocalDateTime.now(), 1L));
+                replyRepository.save(new Reply("name", "contents", LocalDateTime.now(), 1L, 1L));
+                replyRepository.save(new Reply("name", "contents", LocalDateTime.now(), 1L, 1L));
+                replyRepository.save(new Reply("name", "contents", LocalDateTime.now(), 1L, 1L));
+
+                // when
+                int count = replyService.countAll(1L);
+
+                // then
+                assertThat(count).isEqualTo(3);
+            }
+        }
+    }
+
+    @Nested
     class readAll_메소드는 {
 
         @Nested

--- a/src/test/java/com/wootecam/jspcafe/service/ReplyServiceTest.java
+++ b/src/test/java/com/wootecam/jspcafe/service/ReplyServiceTest.java
@@ -58,7 +58,7 @@ class ReplyServiceTest extends ServiceTest {
         class 질문에_댓글이_달려있다면 {
 
             @Test
-            void 모든_댓글을_조회한다() {
+            void 지정된_갯수의_댓글을_조회한다() {
                 // given
                 userRepository.save(new User("userId", "password", "name", "mail@mail.com"));
                 questionRepository.save(new Question("userId", "title", "contents", LocalDateTime.now(), 1L));
@@ -67,10 +67,10 @@ class ReplyServiceTest extends ServiceTest {
                 replyRepository.save(new Reply("userId", "contents", LocalDateTime.now(), 1L, 1L));
 
                 // when
-                List<Reply> replies = replyService.readAll(1L);
+                List<Reply> replies = replyService.readAll(1L, 2);
 
                 // then
-                assertThat(replies).hasSize(3);
+                assertThat(replies).hasSize(2);
             }
         }
 
@@ -84,10 +84,26 @@ class ReplyServiceTest extends ServiceTest {
                 questionRepository.save(new Question("userId", "title", "contents", LocalDateTime.now(), 1L));
 
                 // when
-                List<Reply> replies = replyService.readAll(1L);
+                List<Reply> replies = replyService.readAll(1L, 1);
 
                 // then
                 assertThat(replies).isEmpty();
+            }
+        }
+
+        @Nested
+        class 댓글_조회_갯수가_1개_미만이라면 {
+
+            @Test
+            void 예외가_발생한다() {
+                // given
+                userRepository.save(new User("userId", "password", "name", "mail@mail.com"));
+                questionRepository.save(new Question("userId", "title", "contents", LocalDateTime.now(), 1L));
+
+                // expect
+                assertThatThrownBy(() -> replyService.readAll(1L, 0))
+                        .isInstanceOf(BadRequestException.class)
+                        .hasMessage("댓글 조회 갯수는 1개 이상이어야 합니다.");
             }
         }
     }
@@ -107,7 +123,7 @@ class ReplyServiceTest extends ServiceTest {
 
                 // when
                 replyService.delete(1L, 1L);
-                List<Reply> replies = replyRepository.findAllByQuestionPrimaryId(1L);
+                List<Reply> replies = replyRepository.findAllByQuestionPrimaryIdLimit(1L, 1);
 
                 // then
                 assertThat(replies).isEmpty();
@@ -145,6 +161,48 @@ class ReplyServiceTest extends ServiceTest {
                 assertThatThrownBy(() -> replyService.delete(2L, 1L))
                         .isInstanceOf(NotFoundException.class)
                         .hasMessage("댓글을 찾을 수 없습니다.");
+            }
+        }
+    }
+
+    @Nested
+    class readAllStartsWith_메소드는 {
+
+        @Nested
+        class 조회할_댓글의_갯수가_1개_미만이라면 {
+
+            @Test
+            void 예외가_발생한다() {
+                // given
+                userRepository.save(new User("userId", "password", "name", "mail@mail.com"));
+                questionRepository.save(new Question("userId", "title", "contents", LocalDateTime.now(), 1L));
+                replyRepository.save(new Reply("userId", "contents", LocalDateTime.now(), 1L, 1L));
+
+                // expect
+                assertThatThrownBy(() -> replyService.readAllStartsWith(1L, 1L, 0))
+                        .isInstanceOf(BadRequestException.class)
+                        .hasMessage("댓글 조회 갯수는 1개 이상이어야 합니다.");
+            }
+        }
+
+        @Nested
+        class questionId와_마지막_조회_댓글id와_앞으로_조회할_댓글수를_전달하면 {
+
+            @Test
+            void 마지막_댓글_이후부터_댓글수만큼_조회합니다() {
+                // given
+                userRepository.save(new User("userId", "password", "name", "mail@mail.com"));
+                questionRepository.save(new Question("userId", "title", "contents", LocalDateTime.now(), 1L));
+                replyRepository.save(new Reply("name", "contents1", LocalDateTime.now(), 1L, 1L));
+                replyRepository.save(new Reply("name", "contents2", LocalDateTime.now(), 1L, 1L));
+                replyRepository.save(new Reply("name", "contents3", LocalDateTime.now(), 1L, 1L));
+                replyRepository.save(new Reply("name", "contents4", LocalDateTime.now(), 1L, 1L));
+
+                // when
+                List<Reply> replies = replyService.readAllStartsWith(1L, 2L, 2);
+
+                assertThat(replies).extracting(Reply::getContents)
+                        .containsExactly("contents3", "contents4");
             }
         }
     }

--- a/src/test/java/com/wootecam/jspcafe/service/fixture/ServiceTest.java
+++ b/src/test/java/com/wootecam/jspcafe/service/fixture/ServiceTest.java
@@ -31,7 +31,7 @@ public class ServiceTest {
 
     @BeforeEach
     void setUpTest() {
-        dataSourceManager = new DataSourceManager(new DataSourceProperty());
+        dataSourceManager = new DataSourceManager(new DataSourceProperty("TEST"));
         jdbcTemplate = new JdbcTemplate(dataSourceManager);
         databaseCleaner = new DatabaseCleaner(jdbcTemplate);
         userRepository = new JdbcUserRepository(jdbcTemplate);

--- a/src/test/java/com/wootecam/jspcafe/service/fixture/ServiceTest.java
+++ b/src/test/java/com/wootecam/jspcafe/service/fixture/ServiceTest.java
@@ -1,6 +1,7 @@
 package com.wootecam.jspcafe.service.fixture;
 
 import com.wootecam.jspcafe.config.DataSourceManager;
+import com.wootecam.jspcafe.config.DataSourceProperty;
 import com.wootecam.jspcafe.config.JdbcTemplate;
 import com.wootecam.jspcafe.domain.QuestionRepository;
 import com.wootecam.jspcafe.domain.ReplyRepository;
@@ -30,7 +31,7 @@ public class ServiceTest {
 
     @BeforeEach
     void setUpTest() {
-        dataSourceManager = new DataSourceManager();
+        dataSourceManager = new DataSourceManager(new DataSourceProperty());
         jdbcTemplate = new JdbcTemplate(dataSourceManager);
         databaseCleaner = new DatabaseCleaner(jdbcTemplate);
         userRepository = new JdbcUserRepository(jdbcTemplate);

--- a/src/test/resources/config/datasource.properties
+++ b/src/test/resources/config/datasource.properties
@@ -1,4 +1,1 @@
-datasource.driverClassName=org.h2.Driver
-datasource.url=jdbc:h2:mem:db
-datasource.user=sa
-datasource.password=
+profile=datasource-test.properties


### PR DESCRIPTION
## 구현 내용
- 질문글 페이징
  - 5개의 버튼이 보이며, 다음 페이지당 15개의 게시글을 보여줍니다.
  - Offset 방식의 페이징으로 구현했습니다.
- 댓글 페이징
  - 5개의 댓글까지 보여주고, 더보기 버튼을 누르면 다음 5개의 댓글을 보여줍니다.
  - 사용자가 댓글을 작성하면 현재 보여지는 댓글 최하단에 댓글이 작성되고, 새로고침을 하게되면 원래 자리인 맨 마지막으로 가게 됩니다.
- GitHub  Actions 배포
  - SSH를 통해 접근해 EC2측 서버의 배포스크립트를 실행시킵니다.
  - 로컬에서 동작하는걸 확인했으니, 현재 이 리포에는 시크릿 키를 넣을 수 없어 실패합니다.
  - 로컬 테스트 성공 결과: https://github.com/HiiWee/jsp-cafe/pull/3
- local, prod 환경 DB 설정 분리
  - 이전까지는 동일한 환경을 공유했습니다. (실제 DB가 아니고 localhost DB설정이 동일함)
  - 운영환경이 변화될 경우와, 별도의 DB로 분리할때 용이성을 위해 DB 설정을 분리했습니다.

<br>

## 고민 사항
### 🤔 질문 페이징 쿼리 개선이 의미가 있나?!
기존 질문 페이징 쿼리는 다음과 같습니다.

```sql
SELECT q.id, writer, title, contents, created_time, users_primary_id, deleted_at
FROM question q
         JOIN (SELECT id
               FROM question
               WHERE deleted_at IS NULL
               ORDER BY id DESC
               LIMIT 15 OFFSET 499985) as temp on temp.id = q.id;
```

 - `id(Auto Increment)`역순으로 조회하므로 `backward indexscan`을 함
 - delete_at IS NULL이어야 삭제되지 않은 질문임을 검증
 - 따라서 커버링 인덱스를 사용하기 위해 조인을 이용했지만, deleted_at 컬럼 때문에 커버링 인덱스가 되지 않습니다.
 - 이를 위해 deleted_at 컬럼에 인덱스를 걸어주는게 올바른 선택인지 고민중입니다.

### 추가
게시글 200만, 댓글 1000만의 데이터가 존재할때, 게시글의 deleted_at에 인덱스를 생성하고 실제 쿼리를 전송했을때
DataGrip환경에선 2배정도 빠른 속도를 보여줬지만, 실제 배포 환경에서 웹 요청 응답 속도는 생각보다 개선되지 않았음을 알 수 있었습니다.
왜 그런지 좀 더 공부해봐야 할 것 같습니다.

- DataGrip 인덱스 있을떄와 없을때의 속도 차이
  <img width="830" alt="인덱스있고,없고 쿼리차이" src="https://github.com/user-attachments/assets/51db2a87-d1c6-4ef6-b09e-b93992a2db56">

- 인덱스가 있을때 웹 응답속도
  <img width="788" alt="스크린샷 2024-08-06 오후 8 22 04" src="https://github.com/user-attachments/assets/0d22707e-bc37-4b73-9381-6cf1be4b4163">

- 인덱스가 없을때 웹 응답속도
  <img width="698" alt="스크린샷 2024-08-06 오후 8 23 53" src="https://github.com/user-attachments/assets/459c3b4d-ad7a-4bd9-b2db-02b90b008a6a">

<br>

## 기타
우테캠 7기 화이팅!