### PR TITLE
[김준기] step-8 페이징 구현하기

### DIFF
--- a/src/main/java/woowa/camp/jspcafe/configuration/AppContextListener.java
+++ b/src/main/java/woowa/camp/jspcafe/configuration/AppContextListener.java
@@ -39,7 +39,8 @@ public class AppContextListener implements ServletContextListener {
         UserRepository userRepository = new DBUserRepository(connector);
         UserService userService = new UserService(userRepository, dateTimeProvider);
 
-        ArticleRepository articleRepository = new DBArticleRepository(connector);
+        DBArticleRepository articleRepository = new DBArticleRepository(connector);
+        articleRepository.initializeCacheTotalArticleCount();
 
         DBReplyRepository replyRepository = new DBReplyRepository(connector);
         ReplyService replyService = new ReplyService(replyRepository, userRepository, dateTimeProvider);

--- a/src/main/java/woowa/camp/jspcafe/repository/article/ArticleRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/article/ArticleRepository.java
@@ -15,7 +15,7 @@ public interface ArticleRepository {
 
     Optional<Article> findNext(Long currentId);
 
-    List<Article> findByOffsetPagination(int offset, int limit);
+    List<Article> findByOffsetPagination(long offset, int limit);
 
     void update(Article article);
 

--- a/src/main/java/woowa/camp/jspcafe/repository/article/ArticleRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/article/ArticleRepository.java
@@ -21,4 +21,6 @@ public interface ArticleRepository {
 
     void softDeleteById(Long id, LocalDate deletedTime);
 
+    Long findAllArticleCounts();
+
 }

--- a/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
@@ -108,7 +108,6 @@ public class DBArticleRepository implements ArticleRepository {
         return Optional.empty();
     }
 
-
     @Override
     public Optional<Article> findNext(Long currentId) {
         String sql = "SELECT * FROM articles WHERE id > ? ORDER BY id ASC LIMIT 1";
@@ -196,6 +195,24 @@ public class DBArticleRepository implements ArticleRepository {
 
         } catch (SQLException e) {
             throw new RuntimeException("Failed to delete article", e);
+        }
+    }
+
+    @Override
+    public Long findAllArticleCounts() {
+        String sql = "SELECT count(a.id) FROM articles a";
+
+        try (Connection connection = connector.getConnection();
+             PreparedStatement pstmt = connection.prepareStatement(sql)) {
+
+            try (ResultSet resultSet = pstmt.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getLong(1);
+                }
+                return 0L;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
@@ -136,7 +136,7 @@ public class DBArticleRepository implements ArticleRepository {
     public List<Article> findByOffsetPagination(int offset, int limit) {
         String sql = "SELECT * FROM articles a "
                 + "WHERE deleted_at IS NULL "
-                + "ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?";
+                + "ORDER BY id DESC LIMIT ? OFFSET ?";
 
         try (Connection connection = connector.getConnection();
              PreparedStatement pstmt = connection.prepareStatement(sql)) {

--- a/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
@@ -132,7 +132,7 @@ public class DBArticleRepository implements ArticleRepository {
 
 
     @Override
-    public List<Article> findByOffsetPagination(int offset, int limit) {
+    public List<Article> findByOffsetPagination(long offset, int limit) {
         String sql = "SELECT * FROM articles a "
                 + "WHERE deleted_at IS NULL "
                 + "ORDER BY id DESC LIMIT ? OFFSET ?";
@@ -141,7 +141,7 @@ public class DBArticleRepository implements ArticleRepository {
              PreparedStatement pstmt = connection.prepareStatement(sql)) {
 
             pstmt.setInt(1, limit);
-            pstmt.setInt(2, offset);
+            pstmt.setLong(2, offset);
 
             try (ResultSet resultSet = pstmt.executeQuery()) {
                 List<Article> articles = new ArrayList<>();

--- a/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
@@ -12,21 +12,25 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import woowa.camp.jspcafe.domain.Article;
 import woowa.camp.jspcafe.infra.DatabaseConnector;
 
 public class DBArticleRepository implements ArticleRepository {
 
+    private static final Logger log = LoggerFactory.getLogger(DBArticleRepository.class);
     private final DatabaseConnector connector;
     private final AtomicLong cachedTotalArticleCount = new AtomicLong();
 
     public DBArticleRepository(DatabaseConnector connector) {
         this.connector = connector;
-        cacheTotalArticleCount();
     }
 
-    private void cacheTotalArticleCount() {
+    public void initializeCacheTotalArticleCount() {
+        log.debug("initializing cache total article count");
         cachedTotalArticleCount.set(readAllArticleCounts());
+        log.debug("cache total article count: {}", cachedTotalArticleCount.get());
     }
 
     @Override

--- a/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/article/DBArticleRepository.java
@@ -200,7 +200,7 @@ public class DBArticleRepository implements ArticleRepository {
 
     @Override
     public Long findAllArticleCounts() {
-        String sql = "SELECT count(a.id) FROM articles a";
+        String sql = "SELECT count(a.id) FROM articles a WHERE deleted_at IS NULL";
 
         try (Connection connection = connector.getConnection();
              PreparedStatement pstmt = connection.prepareStatement(sql)) {

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/DBReplyRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/DBReplyRepository.java
@@ -206,6 +206,26 @@ public class DBReplyRepository implements ReplyRepository {
         }
     }
 
+    @Override
+    public Long findReplyCountsByArticleId(Long articleId) {
+        String sql = "SELECT COUNT(r.reply_id) FROM replies r WHERE article_id = ? AND deleted_at IS NULL";
+
+        try (Connection connection = connector.getConnection();
+             PreparedStatement pstmt = connection.prepareStatement(sql)) {
+
+            pstmt.setLong(1, articleId);
+
+            try (ResultSet resultSet = pstmt.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getLong(1);
+                }
+                return 0L;
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public Reply mapRowToReply(ResultSet rs) throws SQLException {
         Reply reply = new Reply(
                 rs.getLong("user_id"),

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/DBReplyRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/DBReplyRepository.java
@@ -226,6 +226,31 @@ public class DBReplyRepository implements ReplyRepository {
         }
     }
 
+    @Override
+    public Boolean isExistNotAuthorReply(Long articleId, Long authorId) {
+        String sql = "SELECT EXISTS ( "
+                + "SELECT 1 "
+                + "FROM replies r "
+                + "WHERE r.article_id = ? AND r.user_id <> ? AND r.deleted_at IS NULL "
+                + ") AS isExist";
+
+        try (Connection connection = connector.getConnection();
+             PreparedStatement pstmt = connection.prepareStatement(sql)) {
+            pstmt.setLong(1, articleId);
+            pstmt.setLong(2, authorId);
+
+            try (ResultSet rs = pstmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getBoolean("isExist");
+                }
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        return false;
+    }
+
     public Reply mapRowToReply(ResultSet rs) throws SQLException {
         Reply reply = new Reply(
                 rs.getLong("user_id"),

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyCursor.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyCursor.java
@@ -1,0 +1,4 @@
+package woowa.camp.jspcafe.repository.reply;
+
+public record ReplyCursor(Long last, Integer count) {
+}

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
@@ -26,4 +26,6 @@ public interface ReplyRepository {
 
     Long findReplyCountsByArticleId(Long articleId);
 
+    Boolean isExistNotAuthorReply(Long articleId, Long authorId);
+
 }

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
@@ -14,7 +14,7 @@ public interface ReplyRepository {
 
     List<Reply> findByArticleId(Long articleId);
 
-    List<ReplyResponse> findByArticleIdWithUser(Long articleId);
+    List<ReplyResponse> findByArticleIdWithUser(Long articleId, ReplyCursor cursor);
 
     void softDeleteByUserId(Long userId, LocalDateTime deletedTime);
 

--- a/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
+++ b/src/main/java/woowa/camp/jspcafe/repository/reply/ReplyRepository.java
@@ -24,4 +24,6 @@ public interface ReplyRepository {
 
     void update(Reply reply);
 
+    Long findReplyCountsByArticleId(Long articleId);
+
 }

--- a/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
@@ -50,11 +50,20 @@ public class ArticleService {
     }
 
     public ArticleDetailsResponse findArticleDetails(Long id) {
+        log.info("{} 모집공고 찾기 시작", id);
         Article article = findArticle(id);
+        log.info("{} 모집공고 찾기 종료", id);
+        log.info("조회수 증가 시작");
         upHits(article);
-        article = findArticle(id);
+        log.info("조회수 증가 끝");
 
+        log.info("{} 모집공고 찾기 시작", id);
+        article = findArticle(id);
+        log.info("{} 모집공고 찾기 종료", id);
+
+        log.info("{} 게시글작성자 찾기 시작", id);
         User author = findAuthor(article.getAuthorId());
+        log.info("{} 게시글작성자 찾기 종료", id);
         return ArticleDetailsResponse.of(article, author.getId(), author.getNickname());
     }
 

--- a/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
@@ -59,7 +59,7 @@ public class ArticleService {
     }
 
     public List<ArticlePreviewResponse> findArticleList(int page) {
-        int pageSize = 10;
+        int pageSize = 15;
         int offset = (page - 1) * pageSize;
         List<Article> articles = articleRepository.findByOffsetPagination(offset, pageSize);
 

--- a/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
@@ -62,13 +62,13 @@ public class ArticleService {
         long offset = (page - 1) * PageVO.MAX_ROW_COUNT_PER_PAGE;
         List<Article> articles = articleRepository.findByOffsetPagination(offset, PageVO.MAX_ROW_COUNT_PER_PAGE);
 
-        List<ArticlePreviewResponse> articlePreviewRespons = new ArrayList<>();
+        List<ArticlePreviewResponse> articlePreviewResponse = new ArrayList<>();
         for (Article article : articles) {
             User author = findAuthor(article.getAuthorId());
-            articlePreviewRespons.add(ArticlePreviewResponse.of(article, author.getId(), author.getNickname()));
+            articlePreviewResponse.add(ArticlePreviewResponse.of(article, author.getId(), author.getNickname()));
         }
 
-        return articlePreviewRespons;
+        return articlePreviewResponse;
     }
 
     public Long findTotalArticleCounts() {

--- a/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
@@ -58,10 +58,9 @@ public class ArticleService {
         return ArticleDetailsResponse.of(article, author.getId(), author.getNickname());
     }
 
-    public List<ArticlePreviewResponse> findArticleList(int page) {
-        int pageSize = 15;
-        int offset = (page - 1) * pageSize;
-        List<Article> articles = articleRepository.findByOffsetPagination(offset, pageSize);
+    public List<ArticlePreviewResponse> findArticleList(long page) {
+        long offset = (page - 1) * PageVO.MAX_ROW_COUNT_PER_PAGE;
+        List<Article> articles = articleRepository.findByOffsetPagination(offset, PageVO.MAX_ROW_COUNT_PER_PAGE);
 
         List<ArticlePreviewResponse> articlePreviewRespons = new ArrayList<>();
         for (Article article : articles) {

--- a/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
@@ -50,20 +50,12 @@ public class ArticleService {
     }
 
     public ArticleDetailsResponse findArticleDetails(Long id) {
-        log.info("{} 모집공고 찾기 시작", id);
         Article article = findArticle(id);
-        log.info("{} 모집공고 찾기 종료", id);
-        log.info("조회수 증가 시작");
         upHits(article);
-        log.info("조회수 증가 끝");
 
-        log.info("{} 모집공고 찾기 시작", id);
         article = findArticle(id);
-        log.info("{} 모집공고 찾기 종료", id);
 
-        log.info("{} 게시글작성자 찾기 시작", id);
         User author = findAuthor(article.getAuthorId());
-        log.info("{} 게시글작성자 찾기 종료", id);
         return ArticleDetailsResponse.of(article, author.getId(), author.getNickname());
     }
 
@@ -140,9 +132,7 @@ public class ArticleService {
     }
 
     private boolean isExistNotAuthorReply(Article article) {
-        Boolean existNotAuthorReply = replyRepository.isExistNotAuthorReply(article.getId(), article.getAuthorId());
-        log.info("existNotAuthorReply = {}", existNotAuthorReply);
-        return existNotAuthorReply;
+        return replyRepository.isExistNotAuthorReply(article.getId(), article.getAuthorId());
     }
 
     private void validateEditable(User user, User author) {

--- a/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
@@ -71,6 +71,10 @@ public class ArticleService {
         return articlePreviewRespons;
     }
 
+    public Long findTotalArticleCounts() {
+        return articleRepository.findAllArticleCounts();
+    }
+
     private Article findArticle(Long id) {
         return articleRepository.findById(id)
                 .orElseThrow(() -> new ArticleException("Article not found : " + id));

--- a/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ArticleService.java
@@ -139,11 +139,10 @@ public class ArticleService {
         replyRepository.softDeleteByArticleId(articleId, deletedTime.atStartOfDay());
     }
 
-    // FIXME: 대규모 데이터 고려 필요
     private boolean isExistNotAuthorReply(Article article) {
-        List<Reply> replies = replyRepository.findByArticleId(article.getId());
-        return replies.stream()
-                .anyMatch(reply -> !reply.getUserId().equals(article.getAuthorId()));
+        Boolean existNotAuthorReply = replyRepository.isExistNotAuthorReply(article.getId(), article.getAuthorId());
+        log.info("existNotAuthorReply = {}", existNotAuthorReply);
+        return existNotAuthorReply;
     }
 
     private void validateEditable(User user, User author) {

--- a/src/main/java/woowa/camp/jspcafe/service/PageVO.java
+++ b/src/main/java/woowa/camp/jspcafe/service/PageVO.java
@@ -8,20 +8,38 @@ public class PageVO {
     private final long currentPage;
     private long firstPage;
     private long lastPage;
+    private long totalPageCount;
+
+    private boolean previousPageExist;
+    private boolean nextPageExist;
 
     public PageVO(long currentPage, long totalRowCount) {
         this.currentPage = currentPage;
+        setTotalPageCount(totalRowCount);
         setFirstPage();
-        setLastPage(totalRowCount);
+        setLastPage();
+        setPreviousPageExist();
+        setNextPageExist();
+    }
+
+    private void setTotalPageCount(long totalRowCount) {
+        totalPageCount = (totalRowCount + MAX_ROW_COUNT_PER_PAGE - 1) / MAX_ROW_COUNT_PER_PAGE;
     }
 
     private void setFirstPage() {
         firstPage = (currentPage - 1) / MAX_PAGE_COUNT * MAX_PAGE_COUNT + 1;
     }
 
-    private void setLastPage(long totalRowCount) {
-        long totalPageCount = totalRowCount / MAX_ROW_COUNT_PER_PAGE + 1;
+    private void setLastPage() {
         lastPage = Math.min(totalPageCount, firstPage + MAX_PAGE_COUNT - 1);
+    }
+
+    private void setPreviousPageExist() {
+        previousPageExist = firstPage > 1L;
+    }
+
+    private void setNextPageExist() {
+        nextPageExist = lastPage < totalPageCount;
     }
 
     public long getCurrentPage() {
@@ -36,12 +54,23 @@ public class PageVO {
         return lastPage;
     }
 
+    public boolean isNextPageExist() {
+        return nextPageExist;
+    }
+
+    public boolean isPreviousPageExist() {
+        return previousPageExist;
+    }
+
     @Override
     public String toString() {
-        return "Page{" +
-                "curPage=" + currentPage +
+        return "PageVO{" +
+                "currentPage=" + currentPage +
                 ", firstPage=" + firstPage +
                 ", lastPage=" + lastPage +
+                ", totalPageCount=" + totalPageCount +
+                ", previousPageExist=" + previousPageExist +
+                ", nextPageExist=" + nextPageExist +
                 '}';
     }
 }

--- a/src/main/java/woowa/camp/jspcafe/service/PageVO.java
+++ b/src/main/java/woowa/camp/jspcafe/service/PageVO.java
@@ -1,0 +1,47 @@
+package woowa.camp.jspcafe.service;
+
+public class PageVO {
+
+    public static final int MAX_ROW_COUNT_PER_PAGE = 15;    // 한 페이지에 보여지는 Row 최대 개수
+    public static final int MAX_PAGE_COUNT = 10;   // 페이지 버튼의 최대 개수
+
+    private final long currentPage;
+    private long firstPage;
+    private long lastPage;
+
+    public PageVO(long currentPage, long totalRowCount) {
+        this.currentPage = currentPage;
+        setFirstPage();
+        setLastPage(totalRowCount);
+    }
+
+    private void setFirstPage() {
+        firstPage = (currentPage - 1) / MAX_PAGE_COUNT * MAX_PAGE_COUNT + 1;
+    }
+
+    private void setLastPage(long totalRowCount) {
+        long totalPageCount = totalRowCount / MAX_ROW_COUNT_PER_PAGE + 1;
+        lastPage = Math.min(totalPageCount, firstPage + MAX_PAGE_COUNT - 1);
+    }
+
+    public long getCurrentPage() {
+        return currentPage;
+    }
+
+    public long getFirstPage() {
+        return firstPage;
+    }
+
+    public long getLastPage() {
+        return lastPage;
+    }
+
+    @Override
+    public String toString() {
+        return "Page{" +
+                "curPage=" + currentPage +
+                ", firstPage=" + firstPage +
+                ", lastPage=" + lastPage +
+                '}';
+    }
+}

--- a/src/main/java/woowa/camp/jspcafe/service/PageVO.java
+++ b/src/main/java/woowa/camp/jspcafe/service/PageVO.java
@@ -6,40 +6,40 @@ public class PageVO {
     public static final int MAX_PAGE_COUNT = 10;   // 페이지 버튼의 최대 개수
 
     private final long currentPage;
-    private long firstPage;
-    private long lastPage;
-    private long totalPageCount;
+    private final long firstPage;
+    private final long lastPage;
+    private final long totalPageCount;
 
-    private boolean previousPageExist;
-    private boolean nextPageExist;
+    private final boolean previousPageExist;
+    private final boolean nextPageExist;
 
     public PageVO(long currentPage, long totalRowCount) {
         this.currentPage = currentPage;
-        setTotalPageCount(totalRowCount);
-        setFirstPage();
-        setLastPage();
-        setPreviousPageExist();
-        setNextPageExist();
+        this.totalPageCount = calculateTotalPageCount(totalRowCount);
+        this.firstPage = calculateFirstPage();
+        this.lastPage = calculateLastPage();
+        this.previousPageExist = calculatePreviousPageExist();
+        this.nextPageExist = calculateNextPageExist();
     }
 
-    private void setTotalPageCount(long totalRowCount) {
-        totalPageCount = (totalRowCount + MAX_ROW_COUNT_PER_PAGE - 1) / MAX_ROW_COUNT_PER_PAGE;
+    private long calculateTotalPageCount(long totalRowCount) {
+        return (totalRowCount + MAX_ROW_COUNT_PER_PAGE - 1) / MAX_ROW_COUNT_PER_PAGE;
     }
 
-    private void setFirstPage() {
-        firstPage = (currentPage - 1) / MAX_PAGE_COUNT * MAX_PAGE_COUNT + 1;
+    private long calculateFirstPage() {
+        return (currentPage - 1) / MAX_PAGE_COUNT * MAX_PAGE_COUNT + 1;
     }
 
-    private void setLastPage() {
-        lastPage = Math.min(totalPageCount, firstPage + MAX_PAGE_COUNT - 1);
+    private long calculateLastPage() {
+        return Math.min(totalPageCount, firstPage + MAX_PAGE_COUNT - 1);
     }
 
-    private void setPreviousPageExist() {
-        previousPageExist = firstPage > 1L;
+    private boolean calculatePreviousPageExist() {
+        return firstPage > 1L;
     }
 
-    private void setNextPageExist() {
-        nextPageExist = lastPage < totalPageCount;
+    private boolean calculateNextPageExist() {
+        return lastPage < totalPageCount;
     }
 
     public long getCurrentPage() {

--- a/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
@@ -54,11 +54,8 @@ public class ReplyService {
     }
 
     public List<ReplyResponse> findReplyList(Long articleId, Long lastReplyId) {
-        log.info("{} 게시글에 대한 댓글 리스트 찾기 시작", articleId);
         ReplyCursor cursor = new ReplyCursor(lastReplyId, 5);
-        List<ReplyResponse> byArticleIdWithUser = replyRepository.findByArticleIdWithUser(articleId, cursor);
-        log.info("{} 게시글에 대한 댓글 리스트 찾기 종료", articleId);
-        return byArticleIdWithUser;
+        return replyRepository.findByArticleIdWithUser(articleId, cursor);
     }
 
     public void deleteReply(User user, Long articleId, Long replyId) {

--- a/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
@@ -49,6 +49,10 @@ public class ReplyService {
                 reply.getUserId(), replier.getNickname(), reply.getCreatedAt());
     }
 
+    public Long findReplyCounts(Long articleId) {
+        return replyRepository.findReplyCountsByArticleId(articleId);
+    }
+
     public List<ReplyResponse> findReplyList(Long articleId, Long lastReplyId) {
         log.info("{} 게시글에 대한 댓글 리스트 찾기 시작", articleId);
         ReplyCursor cursor = new ReplyCursor(lastReplyId, 5);

--- a/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
+++ b/src/main/java/woowa/camp/jspcafe/service/ReplyService.java
@@ -3,6 +3,8 @@ package woowa.camp.jspcafe.service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import woowa.camp.jspcafe.domain.Reply;
 import woowa.camp.jspcafe.domain.User;
 import woowa.camp.jspcafe.domain.exception.ArticleException;
@@ -11,11 +13,14 @@ import woowa.camp.jspcafe.domain.exception.UnAuthorizationException;
 import woowa.camp.jspcafe.domain.exception.UserException;
 import woowa.camp.jspcafe.infra.time.DateTimeProvider;
 import woowa.camp.jspcafe.repository.dto.response.ReplyResponse;
+import woowa.camp.jspcafe.repository.reply.ReplyCursor;
 import woowa.camp.jspcafe.repository.reply.ReplyRepository;
 import woowa.camp.jspcafe.repository.user.UserRepository;
 import woowa.camp.jspcafe.service.dto.request.ReplyWriteRequest;
 
 public class ReplyService {
+
+    private static final Logger log = LoggerFactory.getLogger(ReplyService.class);
 
     private final ReplyRepository replyRepository;
     private final UserRepository userRepository;
@@ -44,8 +49,12 @@ public class ReplyService {
                 reply.getUserId(), replier.getNickname(), reply.getCreatedAt());
     }
 
-    public List<ReplyResponse> findReplyList(Long articleId) {
-        return replyRepository.findByArticleIdWithUser(articleId);
+    public List<ReplyResponse> findReplyList(Long articleId, Long lastReplyId) {
+        log.info("{} 게시글에 대한 댓글 리스트 찾기 시작", articleId);
+        ReplyCursor cursor = new ReplyCursor(lastReplyId, 5);
+        List<ReplyResponse> byArticleIdWithUser = replyRepository.findByArticleIdWithUser(articleId, cursor);
+        log.info("{} 게시글에 대한 댓글 리스트 찾기 종료", articleId);
+        return byArticleIdWithUser;
     }
 
     public void deleteReply(User user, Long articleId, Long replyId) {

--- a/src/main/java/woowa/camp/jspcafe/web/filter/AuthenticationFilter.java
+++ b/src/main/java/woowa/camp/jspcafe/web/filter/AuthenticationFilter.java
@@ -36,7 +36,6 @@ public class AuthenticationFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        log.info("AuthenticationFilter doFilter start");
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         if (isUnAuthenticateAPI(httpRequest)) {
             chain.doFilter(request, response);

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleEditServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleEditServlet.java
@@ -37,7 +37,6 @@ public class ArticleEditServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("ArticleEditServlet doGet start");
         Map<String, String> pathVariables = PathVariableExtractor.extractPathVariables("/articles/edit/{articleId}",
                 req.getRequestURI());
         Long articleId = Long.parseLong(pathVariables.get("articleId"));
@@ -49,12 +48,10 @@ public class ArticleEditServlet extends HttpServlet {
         req.setAttribute("article", updateArticle);
         RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/article/update_form.jsp");
         requestDispatcher.forward(req, resp);
-        log.debug("ArticleEditServlet doGet end");
     }
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("ArticleEditServlet doPost start");
         String method = req.getParameter("_method");
         if ("PUT".equalsIgnoreCase(method)) {
             doPut(req, resp);
@@ -63,14 +60,11 @@ public class ArticleEditServlet extends HttpServlet {
 
         if ("DELETE".equalsIgnoreCase(method)) {
             doDelete(req, resp);
-            return;
         }
-        log.debug("ArticleEditServlet doPost end");
     }
 
     @Override
     protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("ArticleEditServlet doPut start");
         HttpSession session = req.getSession();
         User sessionUser = (User) session.getAttribute("WOOWA_SESSIONID");
 
@@ -84,12 +78,10 @@ public class ArticleEditServlet extends HttpServlet {
         articleService.updateArticle(sessionUser, articleId, articleUpdateRequest);
 
         resp.sendRedirect(req.getContextPath() + "/articles/" + articleId);
-        log.debug("ArticleEditServlet doPut end");
     }
 
     @Override
     protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("ArticleEditServlet doDelete start");
         HttpSession session = req.getSession();
         User sessionUser = (User) session.getAttribute("WOOWA_SESSIONID");
 
@@ -99,6 +91,5 @@ public class ArticleEditServlet extends HttpServlet {
 
         articleService.deleteArticle(sessionUser, articleId);
         resp.sendRedirect(req.getContextPath() + "/");
-        log.debug("ArticleEditServlet doDelete end");
     }
 }

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleServlet.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import woowa.camp.jspcafe.repository.dto.response.ReplyResponse;
 import woowa.camp.jspcafe.service.ArticleService;
 import woowa.camp.jspcafe.service.PageVO;
 import woowa.camp.jspcafe.service.ReplyService;
@@ -88,7 +87,13 @@ public class ArticleServlet extends HttpServlet {
         log.info("handleDetailArticle start");
         Long articleId = Long.parseLong(pathVariables.get("id"));
         ArticleDetailsResponse articleDetails = articleService.findArticleDetails(articleId);
+        Long replyCounts = replyService.findReplyCounts(articleId);
+
         req.setAttribute("article", articleDetails);
+        req.setAttribute("replyCounts", replyCounts);
+
+        log.info("articleDetails {}", articleDetails);
+        log.info("replyCounts {}", replyCounts);
 
         RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/article/show.jsp");
         requestDispatcher.forward(req, resp);

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleServlet.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import woowa.camp.jspcafe.repository.dto.response.ReplyResponse;
 import woowa.camp.jspcafe.service.ArticleService;
+import woowa.camp.jspcafe.service.PageVO;
 import woowa.camp.jspcafe.service.ReplyService;
 import woowa.camp.jspcafe.service.dto.response.ArticleDetailsResponse;
 import woowa.camp.jspcafe.service.dto.response.ArticlePreviewResponse;
@@ -59,22 +60,27 @@ public class ArticleServlet extends HttpServlet {
     }
 
     private void handleArticles(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        int currentPage = 1;
-        int totalPage = 10;
-        String pageParam = req.getParameter("page");
-
-        if (pageParam != null && !pageParam.isEmpty()) {
-            currentPage = Integer.parseInt(pageParam);
-        }
+        long currentPage = getCurrentPage(req);
         List<ArticlePreviewResponse> articles = articleService.findArticleList(currentPage);
+        Long totalArticleCounts = articleService.findTotalArticleCounts();
+        PageVO page = new PageVO(currentPage, totalArticleCounts);
+        log.info("page - {}", page);
 
-        req.setAttribute("currentPage", currentPage);
-        req.setAttribute("totalPages", totalPage);
         req.setAttribute("articles", articles);
+        req.setAttribute("totalArticleCounts", totalArticleCounts);
+        req.setAttribute("page", page);
 
         RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/index.jsp");
         requestDispatcher.forward(req, resp);
         log.debug("ArticleServlet doGet end");
+    }
+
+    private long getCurrentPage(HttpServletRequest req) {
+        String pageParam = req.getParameter("page");
+        if (pageParam != null && !pageParam.isEmpty()) {
+            return Long.parseLong(pageParam);
+        }
+        return 1;
     }
 
     private void handleDetailArticle(HttpServletRequest req, HttpServletResponse resp,

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleServlet.java
@@ -87,12 +87,8 @@ public class ArticleServlet extends HttpServlet {
                                      Map<String, String> pathVariables) throws ServletException, IOException {
         log.info("handleDetailArticle start");
         Long articleId = Long.parseLong(pathVariables.get("id"));
-        Long lastReplyId = Long.parseLong(pathVariables.get("lastReplyId"));
         ArticleDetailsResponse articleDetails = articleService.findArticleDetails(articleId);
-        List<ReplyResponse> replies = replyService.findReplyList(articleId, lastReplyId);
-
         req.setAttribute("article", articleDetails);
-        req.setAttribute("comments", replies);
 
         RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/article/show.jsp");
         requestDispatcher.forward(req, resp);

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleServlet.java
@@ -85,15 +85,17 @@ public class ArticleServlet extends HttpServlet {
 
     private void handleDetailArticle(HttpServletRequest req, HttpServletResponse resp,
                                      Map<String, String> pathVariables) throws ServletException, IOException {
-
+        log.info("handleDetailArticle start");
         Long articleId = Long.parseLong(pathVariables.get("id"));
+        Long lastReplyId = Long.parseLong(pathVariables.get("lastReplyId"));
         ArticleDetailsResponse articleDetails = articleService.findArticleDetails(articleId);
-        List<ReplyResponse> replies = replyService.findReplyList(articleId);
+        List<ReplyResponse> replies = replyService.findReplyList(articleId, lastReplyId);
 
         req.setAttribute("article", articleDetails);
         req.setAttribute("comments", replies);
 
         RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/article/show.jsp");
         requestDispatcher.forward(req, resp);
+        log.info("handleDetailArticle end");
     }
 }

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleServlet.java
@@ -46,7 +46,6 @@ public class ArticleServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("ArticleServlet doGet start");
         String contextPath = req.getContextPath();
         Map<String, String> pathVariables;
 
@@ -63,7 +62,6 @@ public class ArticleServlet extends HttpServlet {
         List<ArticlePreviewResponse> articles = articleService.findArticleList(currentPage);
         Long totalArticleCounts = articleService.findTotalArticleCounts();
         PageVO page = new PageVO(currentPage, totalArticleCounts);
-        log.info("page - {}", page);
 
         req.setAttribute("articles", articles);
         req.setAttribute("totalArticleCounts", totalArticleCounts);
@@ -71,7 +69,6 @@ public class ArticleServlet extends HttpServlet {
 
         RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/index.jsp");
         requestDispatcher.forward(req, resp);
-        log.debug("ArticleServlet doGet end");
     }
 
     private long getCurrentPage(HttpServletRequest req) {
@@ -84,7 +81,6 @@ public class ArticleServlet extends HttpServlet {
 
     private void handleDetailArticle(HttpServletRequest req, HttpServletResponse resp,
                                      Map<String, String> pathVariables) throws ServletException, IOException {
-        log.info("handleDetailArticle start");
         Long articleId = Long.parseLong(pathVariables.get("id"));
         ArticleDetailsResponse articleDetails = articleService.findArticleDetails(articleId);
         Long replyCounts = replyService.findReplyCounts(articleId);
@@ -92,11 +88,7 @@ public class ArticleServlet extends HttpServlet {
         req.setAttribute("article", articleDetails);
         req.setAttribute("replyCounts", replyCounts);
 
-        log.info("articleDetails {}", articleDetails);
-        log.info("replyCounts {}", replyCounts);
-
         RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/article/show.jsp");
         requestDispatcher.forward(req, resp);
-        log.info("handleDetailArticle end");
     }
 }

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleWriteServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/article/ArticleWriteServlet.java
@@ -33,15 +33,12 @@ public class ArticleWriteServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("ArticleWriteServlet doGet start");
         RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/article/form.jsp");
         requestDispatcher.forward(req, resp);
-        log.debug("ArticleWriteServlet doGet end");
     }
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("ArticleWriteServlet doPost start");
         String title = req.getParameter("title");
         String content = req.getParameter("content");
 
@@ -51,6 +48,5 @@ public class ArticleWriteServlet extends HttpServlet {
 
         String contextPath = req.getContextPath();
         resp.sendRedirect(contextPath + "/");
-        log.debug("ArticleWriteServlet doPost end");
     }
 }

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
@@ -36,14 +36,12 @@ public class ReplyServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("ReplyServlet doGet start");
         Long articleId = Long.parseLong(req.getParameter("articleId"));
         Long lastReplyId = null;
         String lastReplyIdParam = req.getParameter("lastReplyId");
         if (lastReplyIdParam != null && !lastReplyIdParam.isEmpty()) {
             lastReplyId = Long.parseLong(lastReplyIdParam);
         }
-        log.info("lastReplyId: {}", lastReplyId);
 
         List<ReplyResponse> replies = replyService.findReplyList(articleId, lastReplyId);
 
@@ -52,12 +50,10 @@ public class ReplyServlet extends HttpServlet {
 
         resp.setContentType("application/json");
         resp.getWriter().write(result);
-        log.debug("ReplyServlet doGet end");
     }
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("ReplyServlet doPost start");
         HttpSession session = req.getSession();
         User sessionUser = (User) session.getAttribute("WOOWA_SESSIONID");
 
@@ -72,21 +68,17 @@ public class ReplyServlet extends HttpServlet {
 
         resp.setContentType("application/json");
         resp.getWriter().write(result);
-        log.debug("ReplyServlet doPost end");
     }
 
     @Override
     protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("ReplyServlet doDelete start");
         HttpSession session = req.getSession();
         User sessionUser = (User) session.getAttribute("WOOWA_SESSIONID");
 
         Long articleId = Long.parseLong(req.getParameter("articleId"));
         Long replyId = Long.parseLong(req.getParameter("replyId"));
-        log.info("articleId - {}, replyId - {}", articleId, replyId);
 
         replyService.deleteReply(sessionUser, articleId, replyId);
-        log.debug("ReplyServlet doDelete end");
     }
 
 }

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
@@ -38,7 +38,11 @@ public class ReplyServlet extends HttpServlet {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         log.debug("ReplyServlet doGet start");
         Long articleId = Long.parseLong(req.getParameter("articleId"));
-        Long lastReplyId = Long.parseLong(req.getParameter("lastReplyId"));
+        Long lastReplyId = null;
+        String lastReplyIdParam = req.getParameter("lastReplyId");
+        lastReplyId = lastReplyIdParam != null ? Long.parseLong(lastReplyIdParam) : null;
+        log.info("lastReplyId: {}", lastReplyId);
+
         List<ReplyResponse> replies = replyService.findReplyList(articleId, lastReplyId);
 
         ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
@@ -38,7 +38,8 @@ public class ReplyServlet extends HttpServlet {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         log.debug("ReplyServlet doGet start");
         Long articleId = Long.parseLong(req.getParameter("articleId"));
-        List<ReplyResponse> replies = replyService.findReplyList(articleId);
+        Long lastReplyId = Long.parseLong(req.getParameter("lastReplyId"));
+        List<ReplyResponse> replies = replyService.findReplyList(articleId, lastReplyId);
 
         ObjectMapper mapper = new ObjectMapper();
         String result = mapper.writeValueAsString(replies);

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/reply/ReplyServlet.java
@@ -40,7 +40,9 @@ public class ReplyServlet extends HttpServlet {
         Long articleId = Long.parseLong(req.getParameter("articleId"));
         Long lastReplyId = null;
         String lastReplyIdParam = req.getParameter("lastReplyId");
-        lastReplyId = lastReplyIdParam != null ? Long.parseLong(lastReplyIdParam) : null;
+        if (lastReplyIdParam != null && !lastReplyIdParam.isEmpty()) {
+            lastReplyId = Long.parseLong(lastReplyIdParam);
+        }
         log.info("lastReplyId: {}", lastReplyId);
 
         List<ReplyResponse> replies = replyService.findReplyList(articleId, lastReplyId);

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserEditServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserEditServlet.java
@@ -38,7 +38,6 @@ public class UserEditServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("userUpdateServlet doGet start");
         Map<String, String> pathVariables = PathVariableExtractor.extractPathVariables("/users/edit/{userId}",
                 req.getRequestURI());
         Long userId = Long.parseLong(pathVariables.get("userId"));
@@ -56,12 +55,10 @@ public class UserEditServlet extends HttpServlet {
 
         RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/user/update_form.jsp");
         requestDispatcher.forward(req, resp);
-        log.debug("userUpdateServlet doGet end");
     }
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("userUpdateServlet doPost start");
         Map<String, String> pathVariables = PathVariableExtractor.extractPathVariables("/users/edit/{userId}",
                 req.getRequestURI());
         Long userId = Long.parseLong(pathVariables.get("userId"));
@@ -82,7 +79,6 @@ public class UserEditServlet extends HttpServlet {
         userService.updateUserProfile(userId, password, updateRequest);
         String contextPath = req.getContextPath();
         resp.sendRedirect(contextPath + "/users");
-        log.debug("userUpdateServlet doPost end");
     }
 
     private boolean isUnAuthorization(User sessionUser, Long userId) throws IOException {

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserLoginServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserLoginServlet.java
@@ -37,7 +37,6 @@ public class UserLoginServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("userLoginServlet doGet start");
         if (!req.getRequestURI().contains("fail")) {
             RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/user/login.jsp");
             requestDispatcher.forward(req, resp);
@@ -45,13 +44,10 @@ public class UserLoginServlet extends HttpServlet {
         }
         RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/user/login_failed.jsp");
         requestDispatcher.forward(req, resp);
-        log.debug("userLoginServlet doGet end");
     }
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("userLoginServlet doPost start");
-
         String email = req.getParameter("email");
         String password = req.getParameter("password");
         try {
@@ -63,7 +59,6 @@ public class UserLoginServlet extends HttpServlet {
             loginCookie.setPath("/");
             resp.addCookie(loginCookie);
             resp.sendRedirect(req.getContextPath() + "/");
-            log.debug("userLoginServlet doPost end");
         } catch (UserException e) {
             resp.sendRedirect(req.getContextPath() + "/users/login/fail");
         }

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserLogoutServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserLogoutServlet.java
@@ -21,7 +21,7 @@ public class UserLogoutServlet extends HttpServlet {
         HttpSession session = req.getSession(false);
         if (session != null) {
             if (session.getAttribute("WOOWA_SESSIONID") != null) {
-                log.info("loggedInUser 세션이 존재합니다");
+                log.debug("loggedInUser 세션이 존재합니다");
                 session.removeAttribute("WOOWA_SESSIONID");
             }
         }

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserRegistrationServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserRegistrationServlet.java
@@ -35,16 +35,13 @@ public class UserRegistrationServlet extends HttpServlet {
     // 회원가입 폼을 반환
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("userRegistrationServlet doGet start");
         RequestDispatcher requestDispatcher = req.getRequestDispatcher("/WEB-INF/views/user/form.jsp");
         requestDispatcher.forward(req, resp);
-        log.debug("userRegistrationServlet doGet end");
     }
 
     // 회원가입 처리
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("userRegistrationServlet doPost start");
         String email = req.getParameter("email");
         String password = req.getParameter("password");
         String nickname = req.getParameter("nickname");
@@ -54,6 +51,5 @@ public class UserRegistrationServlet extends HttpServlet {
 
         String contextPath = req.getContextPath();
         resp.sendRedirect(contextPath + "/users");
-        log.debug("userRegistrationServlet doPost end");
     }
 }

--- a/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserServlet.java
+++ b/src/main/java/woowa/camp/jspcafe/web/servlet/user/UserServlet.java
@@ -40,14 +40,10 @@ public class UserServlet extends HttpServlet {
     // 회원 목록 조회, 회원 프로필 조회
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        log.debug("userServlet doGet start");
 
         String pathInfo = req.getPathInfo();
-        log.info("pathInfo - {}", pathInfo);
-
         if (pathInfo == null || pathInfo.equals("/")) {
             handleUserList(req, resp);
-            log.debug("userServlet doGet end");
             return;
         }
 
@@ -56,7 +52,6 @@ public class UserServlet extends HttpServlet {
         long id = Long.parseLong(pathVariables.get("id"));
 
         handleUserProfile(req, resp, id);
-        log.debug("userServlet doGet end");
     }
 
     private void handleUserList(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {

--- a/src/main/webapp/WEB-INF/views/article/show.jsp
+++ b/src/main/webapp/WEB-INF/views/article/show.jsp
@@ -25,7 +25,8 @@
     </div>
 
     <div class="comment-section">
-        <h3>댓글 <span id="comment-count">0</span>개</h3>
+        <h3>댓글 ${replyCounts}개</h3>
+<%--        <h3>댓글 <span id="comment-count">0</span>개</h3>--%>
         <div id="comment-list">
             <!-- 댓글 목록이 여기에 동적으로 추가됩니다 -->
         </div>
@@ -148,7 +149,15 @@
                 url: '/comments?articleId=' + articleId + '&replyId=' + replyId,
                 method: 'DELETE',
                 success: function (response) {
-                    loadComments(); // 댓글 목록 새로고침
+                    // 댓글 목록에서 삭제한 댓글 제거
+                    $('div.comment[data-id="' + replyId + '"]').remove();
+
+                    // 댓글 개수 업데이트
+                    const currentCount = parseInt($('#comment-count').text());
+                    $('#comment-count').text(currentCount - 1);
+
+                    // 마지막 댓글 ID 갱신
+                    lastReplyId = $('div.comment').last().data('id') - 1;
                 },
                 error: function (xhr, status, error) {
                     console.error("댓글 삭제 실패:", error);

--- a/src/main/webapp/WEB-INF/views/article/show.jsp
+++ b/src/main/webapp/WEB-INF/views/article/show.jsp
@@ -81,7 +81,6 @@
                         commentCount.text(response.length);
                         lastReplyId = response[response.length - 1].replyId - 1;
                     } else {
-                        commentList.append('<p>댓글이 없습니다.</p>');
                         commentCount.text('0');
                     }
 

--- a/src/main/webapp/WEB-INF/views/article/show.jsp
+++ b/src/main/webapp/WEB-INF/views/article/show.jsp
@@ -46,17 +46,24 @@
 <script>
     $(document).ready(function () {
         const articleId = ${article.articleId};
+        let lastReplyId = null;
+        const pageSize = 5;
 
         // 댓글 목록 불러오기
         function loadComments() {
+            const data = {
+                articleId: articleId,
+                lastReplyId: lastReplyId
+            };
+
             $.ajax({
                 url: '/comments',
                 method: 'GET',
-                data: {articleId: articleId},
-                dataType: 'json', // 명시적으로 JSON 응답을 기대함
+                data: data,
+                dataType: 'json',
                 success: function (response) {
                     const commentList = $('#comment-list');
-                    commentList.empty();
+                    const commentCount = $('#comment-count');
 
                     if (Array.isArray(response) && response.length > 0) {
                         response.forEach(function (comment) {
@@ -70,10 +77,17 @@
                             console.log("commentHtml:", commentHtml);
                             commentList.append(commentHtml);
                         });
-                        $('#comment-count').text(response.length);
+                        commentCount.text(response.length);
+                        lastReplyId = response[response.length - 1].replyId - 1;
                     } else {
                         commentList.append('<p>댓글이 없습니다.</p>');
-                        $('#comment-count').text('0');
+                        commentCount.text('0');
+                    }
+
+                    // 댓글 더보기 버튼 추가
+                    if (response.length === pageSize) {
+                        const loadMoreButton = $('<button class="load-more-comments">더 보기</button>');
+                        commentList.after(loadMoreButton);
                     }
                 },
                 error: function (xhr, status, error) {
@@ -87,6 +101,12 @@
         console.log("페이지 로드 시 댓글 불러오기 시작");
         loadComments();
         console.log("페이지 로드 시 댓글 불러오기 종료");
+
+        // 댓글 더보기 버튼 클릭 시 추가 댓글 불러오기
+        $(document).on('click', '.load-more-comments', function () {
+            $(this).remove(); // 버튼 제거
+            loadComments();
+        });
 
         // 댓글 작성
         $('#comment-form').submit(function (e) {
@@ -107,10 +127,11 @@
                         '<p class="comment-date">' + response.createdAt + '</p>' +
                         '<button class="delete-comment" data-id="' + response.replyId + '">삭제</button>' +
                         '</div>';
-                    $('#comment-list').append(newCommentHtml);
+                    $('#comment-list').prepend(newCommentHtml);
                     // 댓글 수 업데이트
                     const currentCount = parseInt($('#comment-count').text());
                     $('#comment-count').text(currentCount + 1);
+                    lastReplyId = response.replyId;
                 },
                 error: function (xhr, status, error) {
                     console.error("댓글 작성 실패:", error);
@@ -135,7 +156,6 @@
                 }
             });
         });
-
     });
 </script>
 

--- a/src/main/webapp/WEB-INF/views/index.jsp
+++ b/src/main/webapp/WEB-INF/views/index.jsp
@@ -35,7 +35,7 @@
 
     <div style="display: flex; justify-content: space-between; margin-top: 20px; margin-bottom: 150px">
         <div class="pagination">
-            <c:if test="${page.currentPage > 1}">
+            <c:if test="${page.previousPageExist}">
                 <a href="${pageContext.request.contextPath}/articles?page=${page.currentPage - 1}">&lt;</a>
             </c:if>
             <c:forEach begin="${page.firstPage}" end="${page.lastPage}" var="i">
@@ -48,7 +48,7 @@
                     </c:otherwise>
                 </c:choose>
             </c:forEach>
-            <c:if test="${page.currentPage < totalPages}">
+            <c:if test="${page.nextPageExist}">
                 <a href="${pageContext.request.contextPath}/articles?page=${page.currentPage + 1}">&gt;</a>
             </c:if>
         </div>

--- a/src/main/webapp/WEB-INF/views/index.jsp
+++ b/src/main/webapp/WEB-INF/views/index.jsp
@@ -10,7 +10,7 @@
         <H2>김준기 카페입니다 !</H2>
     </div>
 
-<%--    <p style="color: #888888;">전체 글 N개</p>--%>
+    <p style="color: #888888;">전체 글 ${totalArticleCounts}개</p>
 
     <table>
         <thead>
@@ -33,14 +33,14 @@
         </tbody>
     </table>
 
-    <div style="display: flex; justify-content: space-between; margin-top: 20px;">
+    <div style="display: flex; justify-content: space-between; margin-top: 20px; margin-bottom: 150px">
         <div class="pagination">
-            <c:if test="${currentPage > 1}">
-                <a href="${pageContext.request.contextPath}/articles?page=${currentPage - 1}">&lt;</a>
+            <c:if test="${page.currentPage > 1}">
+                <a href="${pageContext.request.contextPath}/articles?page=${page.currentPage - 1}">&lt;</a>
             </c:if>
-            <c:forEach begin="1" end="${totalPages}" var="i">
+            <c:forEach begin="${page.firstPage}" end="${page.lastPage}" var="i">
                 <c:choose>
-                    <c:when test="${i == currentPage}">
+                    <c:when test="${i == page.currentPage}">
                         <a href="#" class="active">${i}</a>
                     </c:when>
                     <c:otherwise>
@@ -48,8 +48,8 @@
                     </c:otherwise>
                 </c:choose>
             </c:forEach>
-            <c:if test="${currentPage < totalPages}">
-                <a href="${pageContext.request.contextPath}/articles?page=${currentPage + 1}">&gt;</a>
+            <c:if test="${page.currentPage < totalPages}">
+                <a href="${pageContext.request.contextPath}/articles?page=${page.currentPage + 1}">&gt;</a>
             </c:if>
         </div>
 
@@ -63,4 +63,4 @@
 </div>
 </body>
 
-<jsp:include page="common/footer.jsp"/>
+<%--<jsp:include page="common/footer.jsp"/>--%>

--- a/src/test/java/woowa/camp/jspcafe/dummy_generator.py
+++ b/src/test/java/woowa/camp/jspcafe/dummy_generator.py
@@ -1,0 +1,84 @@
+import csv
+import random
+from datetime import datetime, timedelta
+import os
+
+# 상수 정의
+USER_COUNT = 10_000
+ARTICLE_COUNT = 10_000_000
+MAX_REPLIES_PER_ARTICLE = 5
+
+# CSV 파일이 저장될 디렉토리 경로 설정
+OUTPUT_DIR = '../dummy_csv'
+
+# 디렉토리가 없으면 생성
+os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+# 시작 날짜 설정 (예: 1년 전)
+START_DATE = datetime.now() - timedelta(days=365)
+
+def generate_users():
+    print('유저 더미 데이터 생성 시작')
+    with open(os.path.join(OUTPUT_DIR, 'users.csv'), 'w', newline='') as file:
+        writer = csv.writer(file)
+        writer.writerow(['email', 'nickname', 'password', 'register_at'])
+        for i in range(1, USER_COUNT + 1):
+            register_date = START_DATE + timedelta(minutes=i)  # 각 사용자마다 1분씩 증가
+            writer.writerow([
+                f'user{i}@example.com',
+                f'user{i}',
+                f'password{i}',
+                register_date.strftime('%Y-%m-%d %H:%M:%S')
+            ])
+    print('유저 더미 데이터 생성 종료')
+
+def generate_articles():
+    print('게시글 더미 데이터 생성 시작')
+    with open(os.path.join(OUTPUT_DIR, 'articles.csv'), 'w', newline='') as file:
+        writer = csv.writer(file)
+        writer.writerow(['author_id', 'title', 'content', 'hits', 'created_at', 'updated_at'])
+        for i in range(1, ARTICLE_COUNT + 1):
+            created_at = START_DATE + timedelta(seconds=i)  # 각 게시글마다 1초씩 증가
+            writer.writerow([
+                random.randint(1, USER_COUNT),
+                f'Title {i}',
+                f'Content {i}',
+                random.randint(0, 1000),
+                created_at.strftime('%Y-%m-%d %H:%M:%S'),
+                created_at.strftime('%Y-%m-%d %H:%M:%S')  # updated_at은 created_at과 동일
+            ])
+    print('게시글 더미 데이터 생성 종료')
+
+def get_random_reply_count():
+    probabilities = [0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.05, 0.05]
+    return random.choices(range(11), weights=probabilities)[0]
+
+def generate_replies():
+    print('댓글 더미 데이터 생성 시작')
+    with open(os.path.join(OUTPUT_DIR, 'replies.csv'), 'w', newline='') as file:
+        writer = csv.writer(file)
+        writer.writerow(['user_id', 'article_id', 'content', 'created_at', 'updated_at'])
+        reply_id = 1
+        total_replies = 0
+        for article_id in range(1, ARTICLE_COUNT + 1):
+            reply_count = get_random_reply_count()
+            total_replies += reply_count
+            for j in range(reply_count):
+                created_at = START_DATE + timedelta(seconds=ARTICLE_COUNT + reply_id)  # 게시글 이후로 시작
+                writer.writerow([
+                    random.randint(1, USER_COUNT),
+                    article_id,
+                    f'Reply content {reply_id}',
+                    created_at.strftime('%Y-%m-%d %H:%M:%S'),
+                    created_at.strftime('%Y-%m-%d %H:%M:%S')  # updated_at은 created_at과 동일
+                ])
+                reply_id += 1
+        print(f"Total replies: {total_replies}, Average replies per article: {total_replies / ARTICLE_COUNT:.2f}")
+
+    print('댓글 더미 데이터 생성 종료')
+
+
+if __name__ == '__main__':
+    generate_users()
+    generate_articles()
+    generate_replies()

--- a/src/test/java/woowa/camp/jspcafe/repository/ArticleRepositoryTest.java
+++ b/src/test/java/woowa/camp/jspcafe/repository/ArticleRepositoryTest.java
@@ -286,20 +286,24 @@ class ArticleRepositoryTest {
         }
 
         @Test
-        @DisplayName("[Success] 게시글을 생성일자 기준으로 내림차순 정렬한다")
+        @DisplayName("[Success] 게시글을 id 기준 내림차순 정렬한다")
         void orderedCreatedAtDesc() {
             Article article1 = ArticleFixture.createArticle1(fixedDateTime.getNow());
-            Article article2 = ArticleFixture.createArticle2(fixedDateTime.getNow().plusDays(1L));
-            Article article3 = ArticleFixture.createArticle3(fixedDateTime.getNow().plusDays(2L));
+            Article article2 = ArticleFixture.createArticle1(fixedDateTime.getNow());
+            Article article3 = ArticleFixture.createArticle1(fixedDateTime.getNow());
+            Article article4 = ArticleFixture.createArticle2(fixedDateTime.getNow().plusDays(1L));
+            Article article5 = ArticleFixture.createArticle3(fixedDateTime.getNow().plusDays(2L));
 
-            repository.save(article3);
-            repository.save(article1);
-            repository.save(article2);
+            article1.setId(repository.save(article1));
+            article2.setId(repository.save(article2));
+            article3.setId(repository.save(article3));
+            article4.setId(repository.save(article4));
+            article5.setId(repository.save(article5));
 
-            List<Article> orderedResults = repository.findByOffsetPagination(0, 10);
+            List<Article> orderedResults = repository.findByOffsetPagination(0, 15);
             assertThat(orderedResults)
                     .usingRecursiveFieldByFieldElementComparator()
-                    .containsExactly(article3, article2, article1);
+                    .containsExactly(article5, article4, article3, article2, article1);
         }
 
     }

--- a/src/test/java/woowa/camp/jspcafe/repository/ArticleRepositoryTest.java
+++ b/src/test/java/woowa/camp/jspcafe/repository/ArticleRepositoryTest.java
@@ -222,7 +222,7 @@ class ArticleRepositoryTest {
 
             // when
             List<Article> firstPage = repository.findByOffsetPagination(0, PAGE_SIZE);
-            System.out.println("firstPage = " + firstPage);
+
             // then
             assertThat(firstPage).hasSize(PAGE_SIZE);
             assertThat(firstPage.get(0).getId()).isEqualTo(15L);

--- a/src/test/java/woowa/camp/jspcafe/repository/reply/ReplyRepositoryTest.java
+++ b/src/test/java/woowa/camp/jspcafe/repository/reply/ReplyRepositoryTest.java
@@ -17,9 +17,9 @@ import woowa.camp.jspcafe.domain.User;
 import woowa.camp.jspcafe.fixture.UserFixture;
 import woowa.camp.jspcafe.infra.DatabaseConnector;
 import woowa.camp.jspcafe.repository.UserDBSetupExtension;
+import woowa.camp.jspcafe.repository.dto.response.ReplyResponse;
 import woowa.camp.jspcafe.repository.user.DBUserRepository;
 import woowa.camp.jspcafe.repository.user.UserRepository;
-import woowa.camp.jspcafe.repository.dto.response.ReplyResponse;
 import woowa.camp.jspcafe.utils.FixedDateTimeProvider;
 
 @ExtendWith(ReplyDBSetupExtension.class)
@@ -327,8 +327,9 @@ class ReplyRepositoryTest {
                     null);
             repository.save(reply1);
             repository.save(reply2);
+            ReplyCursor cursor = new ReplyCursor(2L, 5);
             // when
-            List<ReplyResponse> result = repository.findByArticleIdWithUser(1L);
+            List<ReplyResponse> result = repository.findByArticleIdWithUser(1L, cursor);
             // then
             assertThat(result)
                     .hasSize(2)
@@ -340,9 +341,9 @@ class ReplyRepositoryTest {
                                 ReplyResponse::getUserNickname,
                                 ReplyResponse::getCreatedAt
                         ).containsExactly(
-                                tuple(reply1.getReplyId(), userId1, "Test Comment 1", user1.getNickname(),
-                                        fixedDateTime.getNowAsLocalDateTime().toString()),
                                 tuple(reply2.getReplyId(), userId2, "Test Comment 2", user2.getNickname(),
+                                        fixedDateTime.getNowAsLocalDateTime().toString()),
+                                tuple(reply1.getReplyId(), userId1, "Test Comment 1", user1.getNickname(),
                                         fixedDateTime.getNowAsLocalDateTime().toString())
                         );
                     });

--- a/src/test/java/woowa/camp/jspcafe/service/ArticleServiceTest.java
+++ b/src/test/java/woowa/camp/jspcafe/service/ArticleServiceTest.java
@@ -183,10 +183,10 @@ class ArticleServiceTest {
     class FindArticlesTest {
 
         @Test
-        @DisplayName("[Success] 페이지별로 게시글 목록을 조회할 수 있다")
+        @DisplayName("[Success] 페이지별로 게시글 목록을 15개씩 조회할 수 있다")
         void test1() {
             // given
-            int count = 15;
+            int count = 20;
             setupUsers(count);
             ArticleFixture.createMultipleArticleWriteRequests(count, fixedDateTime.getNow())
                     .forEach(articleWriteRequest -> articleService.writeArticle(articleWriteRequest));
@@ -194,7 +194,7 @@ class ArticleServiceTest {
             List<ArticlePreviewResponse> page1 = articleService.findArticleList(1);
             List<ArticlePreviewResponse> page2 = articleService.findArticleList(2);
             // then
-            assertThat(page1).hasSize(10);
+            assertThat(page1).hasSize(15);
             assertThat(page2).hasSize(5);
         }
 

--- a/src/test/java/woowa/camp/jspcafe/service/ArticleServiceTest.java
+++ b/src/test/java/woowa/camp/jspcafe/service/ArticleServiceTest.java
@@ -122,11 +122,9 @@ class ArticleServiceTest {
             String title = "익명 제목";
             String content = "익명 내용";
             Article article = articleService.writeArticle(new ArticleWriteRequest(user.getId(), title, content));
-            System.out.println("article = " + article);
 
             // when
             ArticleDetailsResponse response = articleService.findArticleDetails(article.getId());
-            System.out.println("response = " + response);
 
             // then
             assertArticleDetailsResponse(response, article, title, content, user.getId(), user.getNickname());


### PR DESCRIPTION
## 구현 내용
### 기능 목록

- [x] 게시글 페이지네이션
```
요구사항:

게시글은 한 페이지에 15개씩 보여준다.
게시글은 생성일 기준 내림차순으로 구현한다.
```

- [x] 메인 페이지 조회 요구사항 추가
```
요구사항:

전체 게시글의 개수를 보여준다.
게시글의 개수에 맞는 페이지 버튼을 10개까지 보여준다.
페이지 버튼은 전체 게시글의 개수만큼 보여준다.
```

- [x] 댓글 페이지네이션
```
요구사항:

한 게시글에 댓글은 5개씩 보여한다. 
댓글은 최근에 작성된 댓글순으로 조회한다.
댓글 더보기 버튼을 누르면 5개씩 댓글을 추가로 조회한다.
```

<br> <br>

## 고민 사항
### 대규모 데이터를 어떻게 세팅해야할까
대규모 데이터를 최소한의 시간으로 세팅하기 위한 다양한 방법들을 참고했습니다. 저번 수업 때 csv 파일로 관리하는 것이 빠른편인 것 같아, csv 파일로 테스트 데이터를 세팅했습니다.

<br>

### 5500만건 데이터를 어떻게 조회하고 최적화해야할까
게시글은 약 1000만건, 댓글은 약 45000만건 정도 세팅되어 있습니다. 게시글 목록조회와 댓글 목록조회는 페이지네이션으로 처리하여 응답시간이 크게 오래걸리지 않습니다. 하지만 게시글 상세조회가 55초 소요되는 문제가 있었습니다. 게시글과 댓글을 Join하는데 댓글의 레코드 개수가 너무 많아서 댓글이 0건임에도 오래걸린 것이었고, 인덱스를 추가하여 약 0.008초 정도로 개선할 수 있었습니다.

전체 게시글 개수를 홈페이지에 보여주어야하는데, 게시글 1000만건에 대해 매번 카운트 쿼리를 날리는 것은 비효율적이라 판단하여 전체 게시글 개수는 메모리 레벨에서 캐싱하여 응답속도를 개선했습니다.

<br>

### Cursor 기반 페이지네이션 + 동적 쿼리
댓글 더보기를 눌러서 댓글을 조회해야하기 때문에 댓글 조회는 커서기반 페이지네이션으로 구현했습니다. 또한 최초에 댓글을 조회할 땐 마지막 ID 값을 알아야하는데, 카운트 쿼리를 날리는 것 보다 where 조건 절을 없애는 것이 효율적이라 판단하여 동적 쿼리로 구현했습니다.

<br> <br>

## 기타
- 배포 url: http://13.124.45.229:8080/